### PR TITLE
DRY Language selector dropdown

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -21,16 +21,14 @@ import styles from "./styles"
 import { useLocation } from "react-router";
 import WalletContainer from "./components/WalletContainer/WalletContainer";
 import CustomDropdown from "../customDropdown/CustomDropdown";
-
+import LanguageDropdown from "../LanguageDropdown/LanguageDropdown";
 import {getAvailableNetworks} from "../../helpers/utils";
 import {useTranslation} from "react-i18next";
-import {localeToLanguageMap} from "../../i18n.js"
 
 const useStyles = makeStyles( styles);
 
 const Header = ({isNightMode, setNightMode}) => {
-    const [language, setLanguage] = React.useState('en');
-    const {t, i18n} = useTranslation();
+    const {t} = useTranslation();
     const history = useHistory();
     const location = useLocation();
     const dispatch = useDispatch();
@@ -41,15 +39,6 @@ const Header = ({isNightMode, setNightMode}) => {
         setMobileOpen(!mobileOpen);
     };
 
-    useEffect(() => {
-        const cachedLanguage = i18n.language;
-        if (!cachedLanguage) {
-          return;
-        }
-    
-        setLanguage( cachedLanguage);
-    }, [i18n.language]);
-
     const handleNetworkSwitch = (event) => {
         dispatch(reduxActions.wallet.setNetwork(event.target.value));
     }
@@ -59,21 +48,6 @@ const Header = ({isNightMode, setNightMode}) => {
             dispatch(reduxActions.wallet.createWeb3Modal());
         }
     }, [dispatch, walletReducer.web3modal]);
-
-    const handleLanguageSwitch = event => {
-        if (!event?.target?.value) return
-        const newLanguage = event.target.value
-        return i18n.changeLanguage( newLanguage).then(() => setLanguage( newLanguage))
-    };
-
-    const languageDropdownOptions = {}
-    Object.keys( localeToLanguageMap).forEach( locale => {
-        languageDropdownOptions[ locale] = localeToLanguageMap[ locale]
-    })
-
-    const languageDropdownCustomRender = (locale) => {
-        return locale.toUpperCase()
-    }
 
     const navLinks = [
         { title: t('home'), path: 'https://beefy.finance' },
@@ -99,7 +73,7 @@ const Header = ({isNightMode, setNightMode}) => {
                             <IconButton onClick={setNightMode} className={classes.hide}>
                                 {isNightMode ? <WbSunny /> : <NightsStay />}
                             </IconButton>
-                            <CustomDropdown list={languageDropdownOptions} selected={language} handler={handleLanguageSwitch} css={{marginLeft: 10}} renderValue={languageDropdownCustomRender}/>
+                            <LanguageDropdown css={{marginLeft: 10}}/>
                             <CustomDropdown list={getAvailableNetworks(true)} selected={walletReducer.network} handler={handleNetworkSwitch} css={{marginLeft: 10}} />
                             <Box ml={1}>
                                 <WalletContainer />
@@ -111,8 +85,8 @@ const Header = ({isNightMode, setNightMode}) => {
                             <Menu fontSize="large" />
                         </IconButton>
                         <Drawer anchor="right" open={mobileOpen} onClose={handleDrawerToggle}>
-                            <CustomDropdown list={languageDropdownOptions} selected={language} handler={handleLanguageSwitch} renderValue={languageDropdownCustomRender} fullWidth/>
-                            <Box mt={0.5}> 
+                            <LanguageDropdown fullWidth/>
+                            <Box mt={0.5}>
                                 <WalletContainer />
                             </Box>
                             <div className={classes.list} role="presentation" onClick={handleDrawerToggle} onKeyDown={handleDrawerToggle}>

--- a/src/components/LanguageDropdown/LanguageDropdown.js
+++ b/src/components/LanguageDropdown/LanguageDropdown.js
@@ -1,0 +1,48 @@
+import React, {useCallback, useEffect} from 'react';
+import CustomDropdown from '../customDropdown';
+import {localeToLanguageMap} from '../../i18n';
+import {useTranslation} from 'react-i18next';
+
+const getSelectedLanguage = i18n => {
+	const cachedLanguage = i18n.language;
+
+	if (!cachedLanguage) {
+		return 'en';
+	}
+
+	if (cachedLanguage in localeToLanguageMap) {
+		return cachedLanguage;
+	}
+
+	const languageCode = cachedLanguage.split('-')[0].toLowerCase();
+	if (languageCode in localeToLanguageMap) {
+		return languageCode;
+	}
+
+	return 'en';
+};
+
+const selectedRenderer = locale => {
+	return locale.toUpperCase();
+};
+
+const LanguageDropdown = (props) => {
+	const {i18n} = useTranslation();
+	const i18nLanguage = getSelectedLanguage(i18n);
+	const [language, setLanguage] = React.useState(i18nLanguage);
+
+	const handleSwitch = useCallback(event => {
+		if (!event?.target?.value) return;
+		const newLanguage = event.target.value;
+		return i18n.changeLanguage(newLanguage);
+	}, [i18n]);
+
+	useEffect(() => {
+		setLanguage(i18nLanguage);
+	}, [setLanguage, i18nLanguage]);
+
+	return <CustomDropdown list={localeToLanguageMap} selected={language} handler={handleSwitch}
+						   renderValue={selectedRenderer} {...props}/>;
+};
+
+export default LanguageDropdown;


### PR DESCRIPTION
- Add `LanguageDropdown` component so code isn't repeated
- i18n is source of truth for current language
- If autodetected language is 2 part code, fallback to first part if we don't have support for full language code. (i.e. use 'en' for 'en-GB'/'en-AU', 'zh' for 'zh-CN', 'zh-TW' etc)