### PR TITLE
Fix vault list scroll when portfolio opened/closed

### DIFF
--- a/src/features/home/components/Portfolio/Portfolio.js
+++ b/src/features/home/components/Portfolio/Portfolio.js
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 import buildChartData from 'helpers/buildChartData';
 import PortfolioItem from './PortfolioItem';
 import Stats from './Stats';
+import { notifyResize } from '../../home';
 import styles from './styles';
 
 const useStyles = makeStyles(styles);
@@ -115,7 +116,11 @@ const Portfolio = () => {
           </Box>
           <Stats stats={globalStats} blurred={hideBalance} />
         </Box>
-        <AnimateHeight duration={500} height={portfolioOpen ? 'auto' : 0}>
+        <AnimateHeight
+          duration={500}
+          height={portfolioOpen ? 'auto' : 0}
+          onAnimationEnd={notifyResize}
+        >
           {userVaults.length > 0 ? (
             <>
               {userVaults.map(vault => (

--- a/src/features/home/home.js
+++ b/src/features/home/home.js
@@ -21,6 +21,12 @@ import Item from './components/Item';
 
 const useStyles = makeStyles(styles);
 
+export function notifyResize() {
+  const event = document.createEvent('HTMLEvents');
+  event.initEvent('resize', true, false);
+  window.dispatchEvent(event);
+}
+
 const DataLoader = memo(function HomeDataLoader() {
   const pricesLastUpdated = useSelector(state => state.pricesReducer.lastUpdated);
   const vaultLastUpdated = useSelector(state => state.vaultReducer.lastUpdated);


### PR DESCRIPTION
Need to notify virtual scroller when anything above it changes in height.

It already listens to window resize event, so we are raising a window resize event after the portfolio open/close animation ends.