### PR TITLE
Improve safety-score text

### DIFF
--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -135,7 +135,7 @@
   "Graph-1Year": "1Y",
   "Graph-PriceTkn": "Token Price",
   "Safety-Score": "SAFETY SCORE",
-  "Safety-ScoreWhat": "What is the Safety Score?",
+  "Safety-ScoreWhat": "The Beefy Safety Score",
   "Safety-ScoreExpl": "The Safety Score is computed by Beefy’s developers when assessing a vault. No score can capture risk levels perfectly, but Beefy finds it a useful gauge in making decisions. The Safety Score ranks a vault from 0 to 10, worst to best.",
   "Safety-HowCalc": "How is it calculated?",
   "Safety-Meaning": "What does this mean?",


### PR DESCRIPTION
Typo and spelling. Also fixed Safety Score and safety score to both uppercase. And changed "What's" to "What is". May delete branch after pulling changes.