### PR TITLE
T-534 Surface wallet errors to user

### DIFF
--- a/src/features/data/actions/wallet-actions.tsx
+++ b/src/features/data/actions/wallet-actions.tsx
@@ -6,7 +6,7 @@ import erc20Abi from '../../../config/abi/erc20.json';
 import vaultAbi from '../../../config/abi/vault.json';
 import beFTMAbi from '../../../config/abi/BeFtmAbi.json';
 import zapAbi from '../../../config/abi/zap.json';
-import { BeefyState } from '../../../redux-types';
+import { BeefyState, BeefyThunk } from '../../../redux-types';
 import { getWalletConnectApiInstance } from '../apis/instances';
 import { ZapEstimate, ZapOptions } from '../apis/zap';
 import { BoostEntity } from '../entities/boost';
@@ -42,12 +42,13 @@ import { reloadBalanceAndAllowanceAndGovRewardsAndBoostData } from './tokens';
 import { getGasPriceOptions } from '../utils/gas-utils';
 import { BeFTMToken, Ftmtoken } from '../../vault/components/BeftmCard/BeFtmToken';
 import { BinSpiritToken } from '../../vault/components/SpiritCard/SpiritToken';
+import { BIG_ZERO } from '../../../helpers/format';
 
 export const WALLET_ACTION = 'WALLET_ACTION';
 export const WALLET_ACTION_RESET = 'WALLET_ACTION_RESET';
 
 const approval = (token: TokenErc20, spenderAddress: string) => {
-  return async (dispatch: Dispatch<any>, getState: () => BeefyState) => {
+  return captureWalletErrors(async (dispatch, getState) => {
     dispatch({ type: WALLET_ACTION_RESET });
     const state = getState();
     const address = selectWalletAddress(state);
@@ -77,11 +78,11 @@ const approval = (token: TokenErc20, spenderAddress: string) => {
         tokens: uniqBy([token, native], 'id'),
       }
     );
-  };
+  });
 };
 
 const deposit = (vault: VaultEntity, amount: BigNumber, max: boolean) => {
-  return async (dispatch: Dispatch<any>, getState: () => BeefyState) => {
+  return captureWalletErrors(async (dispatch, getState) => {
     dispatch({ type: WALLET_ACTION_RESET });
     const state = getState();
     const address = selectWalletAddress(state);
@@ -134,7 +135,7 @@ const deposit = (vault: VaultEntity, amount: BigNumber, max: boolean) => {
         tokens: getVaultTokensToRefresh(state, vault),
       }
     );
-  };
+  });
 };
 
 const beefIn = (
@@ -144,7 +145,7 @@ const beefIn = (
   zapEstimate: ZapEstimate,
   slippageTolerance: number
 ) => {
-  return async (dispatch: Dispatch<any>, getState: () => BeefyState) => {
+  return captureWalletErrors(async (dispatch, getState) => {
     dispatch({ type: WALLET_ACTION_RESET });
     const state = getState();
     const address = selectWalletAddress(state);
@@ -199,11 +200,11 @@ const beefIn = (
         tokens: uniqBy(getVaultTokensToRefresh(state, vault).concat([tokenIn, tokenOut]), 'id'),
       }
     );
-  };
+  });
 };
 
 const beefOut = (vault: VaultEntity, oracleAmount: BigNumber, zapOptions: ZapOptions) => {
-  return async (dispatch: Dispatch<any>, getState: () => BeefyState) => {
+  return captureWalletErrors(async (dispatch, getState) => {
     dispatch({ type: WALLET_ACTION_RESET });
     const state = getState();
     const address = selectWalletAddress(state);
@@ -253,7 +254,7 @@ const beefOut = (vault: VaultEntity, oracleAmount: BigNumber, zapOptions: ZapOpt
         tokens: getVaultTokensToRefresh(state, vault),
       }
     );
-  };
+  });
 };
 
 const beefOutAndSwap = (
@@ -263,7 +264,7 @@ const beefOutAndSwap = (
   zapEstimate: ZapEstimate,
   slippageTolerance: number
 ) => {
-  return async (dispatch: Dispatch<any>, getState: () => BeefyState) => {
+  return captureWalletErrors(async (dispatch, getState) => {
     dispatch({ type: WALLET_ACTION_RESET });
     const state = getState();
     const address = selectWalletAddress(state);
@@ -326,11 +327,11 @@ const beefOutAndSwap = (
         ),
       }
     );
-  };
+  });
 };
 
 const withdraw = (vault: VaultEntity, oracleAmount: BigNumber, max: boolean) => {
-  return async (dispatch: Dispatch<any>, getState: () => BeefyState) => {
+  return captureWalletErrors(async (dispatch, getState) => {
     dispatch({ type: WALLET_ACTION_RESET });
     const state = getState();
     const address = selectWalletAddress(state);
@@ -384,11 +385,11 @@ const withdraw = (vault: VaultEntity, oracleAmount: BigNumber, max: boolean) => 
         tokens: getVaultTokensToRefresh(state, vault),
       }
     );
-  };
+  });
 };
 
 const stakeGovVault = (vault: VaultGov, amount: BigNumber) => {
-  return async (dispatch: Dispatch<any>, getState: () => BeefyState) => {
+  return captureWalletErrors(async (dispatch, getState) => {
     dispatch({ type: WALLET_ACTION_RESET });
     const state = getState();
     const address = selectWalletAddress(state);
@@ -419,11 +420,11 @@ const stakeGovVault = (vault: VaultGov, amount: BigNumber) => {
         govVaultId: vault.id,
       }
     );
-  };
+  });
 };
 
 const unstakeGovVault = (vault: VaultGov, amount: BigNumber) => {
-  return async (dispatch: Dispatch<any>, getState: () => BeefyState) => {
+  return captureWalletErrors(async (dispatch, getState) => {
     dispatch({ type: WALLET_ACTION_RESET });
     const state = getState();
     const address = selectWalletAddress(state);
@@ -460,11 +461,11 @@ const unstakeGovVault = (vault: VaultGov, amount: BigNumber) => {
         govVaultId: vault.id,
       }
     );
-  };
+  });
 };
 
 const claimGovVault = (vault: VaultGov) => {
-  return async (dispatch: Dispatch<any>, getState: () => BeefyState) => {
+  return captureWalletErrors(async (dispatch, getState) => {
     dispatch({ type: WALLET_ACTION_RESET });
     const state = getState();
     const address = selectWalletAddress(state);
@@ -494,11 +495,11 @@ const claimGovVault = (vault: VaultGov) => {
         govVaultId: vault.id,
       }
     );
-  };
+  });
 };
 
 const exitGovVault = (vault: VaultGov) => {
-  return async (dispatch: Dispatch<any>, getState: () => BeefyState) => {
+  return captureWalletErrors(async (dispatch, getState) => {
     dispatch({ type: WALLET_ACTION_RESET });
     const state = getState();
     const address = selectWalletAddress(state);
@@ -536,11 +537,11 @@ const exitGovVault = (vault: VaultGov) => {
         govVaultId: vault.id,
       }
     );
-  };
+  });
 };
 
 const claimBoost = (boost: BoostEntity) => {
-  return async (dispatch: Dispatch<any>, getState: () => BeefyState) => {
+  return captureWalletErrors(async (dispatch, getState) => {
     dispatch({ type: WALLET_ACTION_RESET });
     const state = getState();
     const address = selectWalletAddress(state);
@@ -570,11 +571,11 @@ const claimBoost = (boost: BoostEntity) => {
         boostId: boost.id,
       }
     );
-  };
+  });
 };
 
 const exitBoost = (boost: BoostEntity) => {
-  return async (dispatch: Dispatch<any>, getState: () => BeefyState) => {
+  return captureWalletErrors(async (dispatch, getState) => {
     dispatch({ type: WALLET_ACTION_RESET });
     const state = getState();
     const address = selectWalletAddress(state);
@@ -613,11 +614,11 @@ const exitBoost = (boost: BoostEntity) => {
         boostId: boost.id,
       }
     );
-  };
+  });
 };
 
 const stakeBoost = (boost: BoostEntity, amount: BigNumber) => {
-  return async (dispatch: Dispatch<any>, getState: () => BeefyState) => {
+  return captureWalletErrors(async (dispatch, getState) => {
     dispatch({ type: WALLET_ACTION_RESET });
     const state = getState();
     const address = selectWalletAddress(state);
@@ -650,12 +651,12 @@ const stakeBoost = (boost: BoostEntity, amount: BigNumber) => {
         boostId: boost.id,
       }
     );
-  };
+  });
 };
 
 //const unstakeBoost = (boost: BoostEntity, amount: BigNumber) => {
 const unstakeBoost = (boost: BoostEntity, amount: BigNumber) => {
-  return async (dispatch: Dispatch<any>, getState: () => BeefyState) => {
+  return captureWalletErrors(async (dispatch, getState) => {
     dispatch({ type: WALLET_ACTION_RESET });
     const state = getState();
     const address = selectWalletAddress(state);
@@ -688,11 +689,11 @@ const unstakeBoost = (boost: BoostEntity, amount: BigNumber) => {
         boostId: boost.id,
       }
     );
-  };
+  });
 };
 
 const beFtmDeposit = (contractAddr: string, amount: BigNumber, max: boolean) => {
-  return async (dispatch, getState) => {
+  return captureWalletErrors(async (dispatch, getState) => {
     dispatch({ type: WALLET_ACTION_RESET });
     const state = getState();
     const address = selectWalletAddress(state);
@@ -716,11 +717,11 @@ const beFtmDeposit = (contractAddr: string, amount: BigNumber, max: boolean) => 
       amount: amount,
       token: BeFTMToken,
     });
-  };
+  });
 };
 
 const spiritDeposit = (network, contractAddr, amount, max) => {
-  return async (dispatch, getState) => {
+  return captureWalletErrors(async (dispatch, getState) => {
     dispatch({ type: WALLET_ACTION_RESET });
     const state = getState();
     const address = selectWalletAddress(state);
@@ -745,7 +746,7 @@ const spiritDeposit = (network, contractAddr, amount, max) => {
       amount: new BigNumber(amount).shiftedBy(-BinSpiritToken.decimals),
       token: BinSpiritToken,
     });
-  };
+  });
 };
 
 export const walletActions = {
@@ -766,6 +767,26 @@ export const walletActions = {
   beFtmDeposit,
   spiritDeposit,
 };
+
+function captureWalletErrors<ReturnType>(
+  func: BeefyThunk<Promise<ReturnType>>
+): BeefyThunk<Promise<ReturnType>> {
+  return async (dispatch, getState, extraArgument) => {
+    try {
+      return await func(dispatch, getState, extraArgument);
+    } catch (error) {
+      dispatch(
+        createWalletActionErrorAction(
+          { message: String(error) },
+          {
+            amount: BIG_ZERO,
+            token: null,
+          }
+        )
+      );
+    }
+  };
+}
 
 function bindTransactionEvents<T extends { amount: BigNumber; token: TokenEntity }>(
   dispatch: Dispatch<any>,

--- a/src/redux-types.ts
+++ b/src/redux-types.ts
@@ -1,5 +1,5 @@
-import { EnhancedStore, CombinedState, MiddlewareArray, AnyAction } from '@reduxjs/toolkit';
-import { ThunkMiddleware } from 'redux-thunk';
+import { AnyAction, CombinedState, EnhancedStore, MiddlewareArray } from '@reduxjs/toolkit';
+import { ThunkAction, ThunkMiddleware } from 'redux-thunk';
 import { ApyState } from './features/data/reducers/apy';
 import { BoostsState } from './features/data/reducers/boosts';
 import { BuybackState } from './features/data/reducers/buyback';
@@ -20,6 +20,7 @@ import { WalletActionsState } from './features/data/reducers/wallet/wallet-actio
 import { ZapsState } from './features/data/reducers/zaps';
 import { WithdrawState } from './features/data/reducers/wallet/withdraw';
 import { BoostModalState } from './features/data/reducers/wallet/boost-modal';
+import { Action } from 'redux';
 
 export interface BeefyState {
   entities: {
@@ -59,4 +60,11 @@ export type BeefyStore = EnhancedStore<
     | ((store: any) => (next: any) => (action: any) => any)
     | ThunkMiddleware<CombinedState<BeefyState>, any, null>
   >
+>;
+
+export type BeefyThunk<ReturnType = void> = ThunkAction<
+  ReturnType,
+  BeefyState,
+  unknown,
+  Action<string>
 >;


### PR DESCRIPTION
**Note this will have merge conflicts with PR #606** 

If an error occurred before the TX send (e.g. in gas estimation), wallet actions would silently fail with the error logged to the console, but not shown to user.

This PR will show these errors to the user in the usual transaction box
e.g. If MetaMask hasn't been updated to a version that supports EIP1559, the user will see something similar to this:
![image](https://user-images.githubusercontent.com/55021052/161970918-61559698-3a19-4965-a372-b6e4e4905b55.png)
