### PR TITLE
[Testing] Sync real wallet state with redux state

### DIFF
--- a/src/components/GovVaultRewards/GovVaultRewards.tsx
+++ b/src/components/GovVaultRewards/GovVaultRewards.tsx
@@ -9,10 +9,7 @@ import {
 } from '../../features/data/selectors/balance';
 import { selectTokenById } from '../../features/data/selectors/tokens';
 import { selectVaultById } from '../../features/data/selectors/vaults';
-import {
-  selectIsBalanceHidden,
-  selectIsWalletConnected,
-} from '../../features/data/selectors/wallet';
+import { selectIsBalanceHidden, selectIsWalletKnown } from '../../features/data/selectors/wallet';
 import { formatBigDecimals, formatBigUsd } from '../../helpers/format';
 import { BeefyState } from '../../redux-types';
 import { ValueBlock } from '../ValueBlock/ValueBlock';
@@ -28,7 +25,7 @@ const _GovVaultRewards = connect(
     const rewardsEarnedUsd = selectGovVaultPendingRewardsInUsd(state, vault.id);
     const blurred = selectIsBalanceHidden(state);
     const isLoaded =
-      state.ui.dataLoader.global.prices.alreadyLoadedOnce && selectIsWalletConnected(state)
+      state.ui.dataLoader.global.prices.alreadyLoadedOnce && selectIsWalletKnown(state)
         ? state.ui.dataLoader.byChainId[vault.chainId]?.balance.alreadyLoadedOnce
         : true;
     const hasRewards = rewardsEarnedUsd.gt(0);

--- a/src/components/Header/components/WalletContainer/WalletContainer.tsx
+++ b/src/components/Header/components/WalletContainer/WalletContainer.tsx
@@ -7,7 +7,7 @@ import { ApyStatLoader } from '../../../ApyStatLoader';
 import { useTheme } from '@material-ui/core/styles';
 import {
   selectIsBalanceHidden,
-  selectIsWalletConnected,
+  selectIsWalletKnown,
   selectWalletAddress,
 } from '../../../../features/data/selectors/wallet';
 import { BeefyState } from '../../../../redux-types';
@@ -24,7 +24,7 @@ const formatAddress = addr => {
 };
 
 export const WalletContainer = connect((state: BeefyState) => {
-  const isWalletConnected = selectIsWalletConnected(state);
+  const isWalletConnected = selectIsWalletKnown(state);
   const walletAddress = isWalletConnected ? selectWalletAddress(state) : null;
   const walletPending = selectIsWalletPending(state);
   const walletProfileUrl = state.user.wallet.profilePictureUrl;

--- a/src/components/VaultDeposited/VaultDeposited.tsx
+++ b/src/components/VaultDeposited/VaultDeposited.tsx
@@ -14,10 +14,7 @@ import {
   selectIsVaultBoosted,
 } from '../../features/data/selectors/boosts';
 import { selectVaultById } from '../../features/data/selectors/vaults';
-import {
-  selectIsBalanceHidden,
-  selectIsWalletConnected,
-} from '../../features/data/selectors/wallet';
+import { selectIsBalanceHidden, selectIsWalletKnown } from '../../features/data/selectors/wallet';
 import { formatBigDecimals, formatBigUsd } from '../../helpers/format';
 import { BeefyState } from '../../redux-types';
 import { ValueBlock } from '../ValueBlock/ValueBlock';
@@ -33,7 +30,7 @@ const _BoostedVaultDepositedSmall = connect(
       .join(', ');
     const blurred = selectIsBalanceHidden(state);
     const isLoaded =
-      state.ui.dataLoader.global.prices.alreadyLoadedOnce && selectIsWalletConnected(state)
+      state.ui.dataLoader.global.prices.alreadyLoadedOnce && selectIsWalletKnown(state)
         ? state.ui.dataLoader.byChainId[vault.chainId]?.balance.alreadyLoadedOnce
         : true;
     return {
@@ -70,7 +67,7 @@ const _BoostedVaultDepositedLarge = connect(
     const totalDepositedUsd = formatBigUsd(selectUserVaultDepositInUsd(state, vault.id));
     const blurred = selectIsBalanceHidden(state);
     const isLoaded =
-      state.ui.dataLoader.global.prices.alreadyLoadedOnce && selectIsWalletConnected(state)
+      state.ui.dataLoader.global.prices.alreadyLoadedOnce && selectIsWalletKnown(state)
         ? state.ui.dataLoader.byChainId[vault.chainId]?.balance.alreadyLoadedOnce
         : true;
     return {
@@ -127,7 +124,7 @@ const _NonBoostedVaultDeposited = connect(
     const totalDepositedUsd = formatBigUsd(selectUserVaultDepositInUsd(state, vault.id));
     const blurred = selectIsBalanceHidden(state);
     const isLoaded =
-      state.ui.dataLoader.global.prices.alreadyLoadedOnce && selectIsWalletConnected(state)
+      state.ui.dataLoader.global.prices.alreadyLoadedOnce && selectIsWalletKnown(state)
         ? state.ui.dataLoader.byChainId[vault.chainId]?.balance.alreadyLoadedOnce
         : true;
     return {

--- a/src/components/VaultWalletAmount/VaultWalletAmount.tsx
+++ b/src/components/VaultWalletAmount/VaultWalletAmount.tsx
@@ -5,10 +5,7 @@ import { VaultEntity } from '../../features/data/entities/vault';
 import { selectUserBalanceOfToken } from '../../features/data/selectors/balance';
 import { selectTokenPriceByTokenId } from '../../features/data/selectors/tokens';
 import { selectVaultById } from '../../features/data/selectors/vaults';
-import {
-  selectIsBalanceHidden,
-  selectIsWalletConnected,
-} from '../../features/data/selectors/wallet';
+import { selectIsBalanceHidden, selectIsWalletKnown } from '../../features/data/selectors/wallet';
 import { formatBigDecimals, formatBigUsd } from '../../helpers/format';
 import { BeefyState } from '../../redux-types';
 import { ValueBlock } from '../ValueBlock/ValueBlock';
@@ -25,7 +22,7 @@ const _VaultWalletAmount = connect(
 
     const blurred = selectIsBalanceHidden(state);
     const isLoaded =
-      state.ui.dataLoader.global.prices.alreadyLoadedOnce && selectIsWalletConnected(state)
+      state.ui.dataLoader.global.prices.alreadyLoadedOnce && selectIsWalletKnown(state)
         ? state.ui.dataLoader.byChainId[vault.chainId]?.balance.alreadyLoadedOnce
         : true;
     return {

--- a/src/features/data/actions/scenarios.ts
+++ b/src/features/data/actions/scenarios.ts
@@ -1,6 +1,6 @@
 import { Action } from 'redux';
 import { ChainEntity } from '../entities/chain';
-import { selectIsWalletConnected } from '../selectors/wallet';
+import { selectIsWalletKnown } from '../selectors/wallet';
 import { createFulfilledActionCapturer, poll, PollStop } from '../utils/async-utils';
 import { fetchApyAction } from './apy';
 import { fetchAllBoosts, initiateBoostForm } from './boosts';
@@ -75,7 +75,7 @@ export async function initHomeDataV4(store: BeefyStore) {
   // create the wallet instance as soon as we get the chain list
   setTimeout(async () => {
     await chainListPromise;
-    initWallet(store);
+    store.dispatch(initWallet());
   });
 
   // we need config data (for contract addresses) to start querying the rest
@@ -97,7 +97,7 @@ export async function initHomeDataV4(store: BeefyStore) {
       contractData: captureFulfill(fetchAllContractDataByChainAction({ chainId: chain.id })),
       user: null,
     };
-    if (selectIsWalletConnected(store.getState())) {
+    if (selectIsWalletKnown(store.getState())) {
       fulfillsByNet[chain.id].user = fetchCaptureUserData(store, chain.id);
     }
   }
@@ -169,7 +169,7 @@ export async function initHomeDataV4(store: BeefyStore) {
   // now set regular calls to update user data
   for (const chain of chains) {
     const pollStop = poll(async () => {
-      if (!selectIsWalletConnected(store.getState())) {
+      if (!selectIsWalletKnown(store.getState())) {
         return;
       }
       // trigger all calls at the same time

--- a/src/features/data/apis/wallet/wallet-connect-types.ts
+++ b/src/features/data/apis/wallet/wallet-connect-types.ts
@@ -21,8 +21,13 @@ export interface Provider {
   request: (req: { method: string; params: any[] }) => Promise<void>;
 }
 
+export type initFromLocalCacheResponse = null | {
+  chainId: ChainEntity['id'] | null;
+  address: string;
+};
+
 export interface IWalletConnectApi {
-  initFromLocalCache(): Promise<null | { chainId: ChainEntity['id'] | null; address: string }>;
+  initFromLocalCache(): Promise<initFromLocalCacheResponse>;
   askUserToConnectIfNeeded();
   askUserForChainChangeIfNeeded(chainId: ChainEntity['id']);
   disconnect();

--- a/src/features/data/apis/wallet/wallet-connect.ts
+++ b/src/features/data/apis/wallet/wallet-connect.ts
@@ -12,7 +12,12 @@ import { DeFiConnector } from 'deficonnect';
 import Web3 from 'web3';
 import { ChainEntity } from '../../entities/chain';
 import { find, sample } from 'lodash';
-import { IWalletConnectApi, Provider, WalletConnectOptions } from './wallet-connect-types';
+import {
+  initFromLocalCacheResponse,
+  IWalletConnectApi,
+  Provider,
+  WalletConnectOptions,
+} from './wallet-connect-types';
 import { featureFlag_walletAddressOverride } from '../../utils/feature-flags';
 import { sleep } from '../../utils/async-utils';
 import { maybeHexToNumber } from '../../../../helpers/format';
@@ -26,10 +31,7 @@ export class WalletConnectApi implements IWalletConnectApi {
     this.provider = null;
   }
 
-  public async initFromLocalCache(): Promise<null | {
-    chainId: ChainEntity['id'] | null;
-    address: string;
-  }> {
+  public async initFromLocalCache(): Promise<initFromLocalCacheResponse> {
     try {
       // we check the local cached provider
       // if we have a cached value, we want to have a connected web3Modal instance

--- a/src/features/data/reducers/data-loader.ts
+++ b/src/features/data/reducers/data-loader.ts
@@ -19,11 +19,15 @@ import {
   reloadBalanceAndAllowanceAndGovRewardsAndBoostData,
 } from '../actions/tokens';
 import { fetchAllVaults } from '../actions/vaults';
-import { askForNetworkChange, askForWalletConnection, doDisconnectWallet } from '../actions/wallet';
+import {
+  askForNetworkChange,
+  askForWalletConnection,
+  doDisconnectWallet,
+  initWallet,
+} from '../actions/wallet';
 import { initiateWithdrawForm } from '../actions/withdraw';
 import { fetchAllZapsAction } from '../actions/zap';
 import { ChainEntity } from '../entities/chain';
-import { initWalletState } from './wallet/wallet';
 import { fetchAllMinters, initiateMinterForm } from '../actions/minters';
 
 /**
@@ -247,6 +251,7 @@ export const dataLoaderSlice = createSlice({
   extraReducers: builder => {
     addGlobalAsyncThunkActions(builder, fetchChainConfigs, 'chainConfig', true);
     addGlobalAsyncThunkActions(builder, askForWalletConnection, 'wallet', false);
+    addGlobalAsyncThunkActions(builder, initWallet, 'wallet', false);
     addGlobalAsyncThunkActions(builder, doDisconnectWallet, 'wallet', false);
     addGlobalAsyncThunkActions(builder, askForNetworkChange, 'wallet', false);
     addGlobalAsyncThunkActions(builder, fetchAllPricesAction, 'prices', true);
@@ -269,10 +274,6 @@ export const dataLoaderSlice = createSlice({
       'allowance',
     ]);
     addByChainAsyncThunkActions(builder, fetchAddressBookAction, ['addressBook']);
-
-    builder.addCase(initWalletState, sliceState => {
-      sliceState.instances.wallet = true;
-    });
   },
 });
 

--- a/src/features/data/reducers/index.tsx
+++ b/src/features/data/reducers/index.tsx
@@ -42,7 +42,10 @@ const bizReducer = combineReducers<BeefyState['biz']>({
 const userReducer = combineReducers<BeefyState['user']>({
   balance: balanceSlice.reducer,
   allowance: allowanceSlice.reducer,
-  wallet: persistReducer({ key: 'wallet', storage }, walletSlice.reducer),
+  wallet: persistReducer(
+    { key: 'wallet', storage, blacklist: ['profilePictureUrl', 'error', 'initialized'] },
+    walletSlice.reducer
+  ),
   walletActions: walletActionsReducer,
 });
 const uiReducer = combineReducers<BeefyState['ui']>({

--- a/src/features/data/selectors/balance.ts
+++ b/src/features/data/selectors/balance.ts
@@ -8,10 +8,10 @@ import { isGovVault, VaultEntity, VaultGov } from '../entities/vault';
 import { selectActiveVaultBoostIds, selectAllVaultBoostIds, selectBoostById } from './boosts';
 import { selectTokenById, selectTokenPriceByTokenId } from './tokens';
 import { selectStandardVaultById, selectVaultById, selectVaultPricePerFullShare } from './vaults';
-import { selectIsWalletConnected, selectWalletAddress } from './wallet';
+import { selectIsWalletKnown, selectWalletAddress } from './wallet';
 
 const _selectWalletBalance = (state: BeefyState, walletAddress?: string) => {
-  if (selectIsWalletConnected(state)) {
+  if (selectIsWalletKnown(state)) {
     const userAddress = walletAddress || selectWalletAddress(state);
     if (!userAddress) {
       return null;

--- a/src/features/data/selectors/wallet.ts
+++ b/src/features/data/selectors/wallet.ts
@@ -2,17 +2,21 @@ import { createSelector } from '@reduxjs/toolkit';
 import { BeefyState } from '../../../redux-types';
 import { featureFlag_walletAddressOverride } from '../utils/feature-flags';
 
-export const selectIsWalletConnected = createSelector(
-  // get a tiny bit of the data
+// If we know the address: either from a wallet connection; or from hydration of persisted state from previous visit
+export const selectIsWalletKnown = createSelector(
   (state: BeefyState) => state.user.wallet.address,
-  // last function receives previous function outputs as parameters
   address => address !== null
 );
 
-export const selectWalletAddress = createSelector(
-  // get a tiny bit of the data
+// If we know the address from wallet connection
+export const selectIsWalletConnected = createSelector(
+  (state: BeefyState) => state.user.wallet.initialized,
   (state: BeefyState) => state.user.wallet.address,
-  // last function receives previous function outputs as parameters
+  (initialized, address) => initialized && address !== null
+);
+
+export const selectWalletAddress = createSelector(
+  (state: BeefyState) => state.user.wallet.address,
   address => {
     address = featureFlag_walletAddressOverride(address);
     if (address === null) {
@@ -26,3 +30,4 @@ export const selectCurrentChainId = (state: BeefyState) => state.user.wallet.sel
 export const selectIsBalanceHidden = (state: BeefyState) => state.user.wallet.hideBalance;
 export const selectIsNetworkSupported = (state: BeefyState) =>
   state.user.wallet.error !== 'unsupported chain';
+export const selectIsWalletInitialized = (state: BeefyState) => state.user.wallet.initialized;

--- a/src/features/home/components/EmptyStates/index.tsx
+++ b/src/features/home/components/EmptyStates/index.tsx
@@ -3,28 +3,41 @@ import { Box, Button, makeStyles, Typography } from '@material-ui/core';
 import { styles } from './styles';
 import { useTranslation } from 'react-i18next';
 import { connect, useDispatch } from 'react-redux';
-import { selectIsWalletConnected, selectWalletAddress } from '../../../data/selectors/wallet';
+import {
+  selectIsWalletInitialized,
+  selectIsWalletKnown,
+  selectWalletAddress,
+} from '../../../data/selectors/wallet';
 import { filteredVaultsActions } from '../../../data/reducers/filtered-vaults';
 import { BeefyState } from '../../../../redux-types';
 import { askForWalletConnection, doDisconnectWallet } from '../../../data/actions/wallet';
 
 const useStyles = makeStyles(styles as any);
 const _EmptyStates = connect((state: BeefyState) => {
-  const isWalletConnected = selectIsWalletConnected(state);
-  const walletAddress = isWalletConnected ? selectWalletAddress(state) : null;
-  return { isWalletConnected, walletAddress };
+  const isWalletKnown = selectIsWalletKnown(state);
+  const isWalletInitialized = selectIsWalletInitialized(state);
+  const walletAddress = isWalletKnown ? selectWalletAddress(state) : null;
+  return { isWalletKnown, walletAddress, isWalletInitialized };
 })(
-  ({ isWalletConnected, walletAddress }: { isWalletConnected: boolean; walletAddress: string }) => {
+  ({
+    isWalletKnown,
+    isWalletInitialized,
+    walletAddress,
+  }: {
+    isWalletKnown: boolean;
+    isWalletInitialized: boolean;
+    walletAddress: string;
+  }) => {
     const { t } = useTranslation();
     const classes = useStyles();
     const dispatch = useDispatch();
-    const handleWalletConnect = () => {
+    const handleWalletConnect = useCallback(() => {
       if (walletAddress) {
         dispatch(doDisconnectWallet());
       } else {
         dispatch(askForWalletConnection());
       }
-    };
+    }, [dispatch, walletAddress]);
 
     const handleReset = useCallback(() => dispatch(filteredVaultsActions.reset()), [dispatch]);
 
@@ -44,19 +57,19 @@ const _EmptyStates = connect((state: BeefyState) => {
         </Box>
         <Box>
           <Typography variant="body2" className={classes.text}>
-            {isWalletConnected ? t('EmptyStates-NoDeposited') : t('EmptyStates-NoConnected')}
+            {isWalletKnown ? t('EmptyStates-NoDeposited') : t('EmptyStates-NoConnected')}
           </Typography>
         </Box>
         <Box>
-          {isWalletConnected ? (
+          {isWalletKnown ? (
             <Button className={classes.btn} onClick={handleReset}>
               {t('EmptyStates-Browse')}
             </Button>
-          ) : (
+          ) : isWalletInitialized ? (
             <Button className={classes.btn} onClick={handleWalletConnect}>
               {t('EmptyStates-Connect')}
             </Button>
-          )}
+          ) : null}
         </Box>
       </Box>
     );

--- a/src/features/home/home.tsx
+++ b/src/features/home/home.tsx
@@ -9,7 +9,7 @@ import { styles } from './styles';
 import { AutoSizer } from 'react-virtualized';
 import { CowLoader } from '../../components/CowLoader';
 import { selectIsVaultListAvailable } from '../data/selectors/data-loader';
-import { selectIsWalletConnected } from '../data/selectors/wallet';
+import { selectIsWalletKnown } from '../data/selectors/wallet';
 import { selectFilteredVaults, selectFilterOptions } from '../data/selectors/filtered-vaults';
 import { Item } from './components/Item';
 import { debounce } from 'lodash';
@@ -151,7 +151,7 @@ const VaultsList = memo(function HomeVaultsList() {
   // we switch to vault cards on smaller screens or when doing 2 columns
   const isVaultCard = useMediaQuery('(max-width: 959px)');
   const filterOptions = useSelector(selectFilterOptions);
-  const isWalletConnected = useSelector(selectIsWalletConnected);
+  const isWalletKnown = useSelector(selectIsWalletKnown);
   const vaults = useSelector(selectFilteredVaults);
   const spaceBetweenRows = 20;
   const classes = useStyles(spaceBetweenRows);
@@ -179,11 +179,11 @@ const VaultsList = memo(function HomeVaultsList() {
 
   return (
     <div className={classes.vaultsList}>
-      {filterOptions.userCategory === 'deposited' && isWalletConnected && vaults.length === 0 && (
+      {filterOptions.userCategory === 'deposited' && isWalletKnown && vaults.length === 0 && (
         <EmptyStates />
       )}
-      {filterOptions.userCategory === 'deposited' && !isWalletConnected && <EmptyStates />}
-      {filterOptions.userCategory === 'eligible' && !isWalletConnected && <EmptyStates />}
+      {filterOptions.userCategory === 'deposited' && !isWalletKnown && <EmptyStates />}
+      {filterOptions.userCategory === 'eligible' && !isWalletKnown && <EmptyStates />}
       <LargeList
         batchSize={5}
         spaceBetweenRows={spaceBetweenRows}

--- a/src/features/vault/components/BoostWidget/BoostWidgetActiveBoost.tsx
+++ b/src/features/vault/components/BoostWidget/BoostWidgetActiveBoost.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Box, Button, makeStyles, Typography, Grid, Modal } from '@material-ui/core';
+import { Box, Button, Grid, makeStyles, Modal, Typography } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { styles } from './styles';
 import { Popover } from '../../../../components/Popover/Popover';
 import { formatBigDecimals } from '../../../../helpers/format';
@@ -58,7 +58,7 @@ export function BoostWidgetActiveBoost({ boostId }: { boostId: BoostEntity['id']
   const { t } = useTranslation();
   const dispatch = useDispatch();
 
-  const isWalletConnected = useSelector((state: BeefyState) => selectIsWalletConnected(state));
+  const isWalletConnected = useSelector(selectIsWalletConnected);
   const isWalletOnVaultChain = useSelector(
     (state: BeefyState) => selectCurrentChainId(state) === boost.chainId
   );
@@ -72,6 +72,7 @@ export function BoostWidgetActiveBoost({ boostId }: { boostId: BoostEntity['id']
     setDw(deposit);
     setInputModal(true);
   }
+
   const closeInputModal = () => {
     setInputModal(false);
   };

--- a/src/features/vault/components/BoostWidget/BoostWidgetPastBoosts.tsx
+++ b/src/features/vault/components/BoostWidget/BoostWidgetPastBoosts.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, makeStyles, Typography } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import AnimateHeight from 'react-animate-height';
 import { styles } from './styles';
 import { askForNetworkChange, askForWalletConnection } from '../../../data/actions/wallet';
@@ -17,6 +17,7 @@ import { walletActions } from '../../../data/actions/wallet-actions';
 import { BoostEntity } from '../../../data/entities/boost';
 import { selectVaultById } from '../../../data/selectors/vaults';
 import { selectChainById } from '../../../data/selectors/chains';
+
 const useStyles = makeStyles(styles as any);
 
 export function BoostWidgetPastBoosts({ vaultId }: { vaultId: BoostEntity['id'] }) {
@@ -32,7 +33,7 @@ export function BoostWidgetPastBoosts({ vaultId }: { vaultId: BoostEntity['id'] 
       selectBoostById(state, boostId)
     )
   );
-  const isWalletConnected = useSelector((state: BeefyState) => selectIsWalletConnected(state));
+  const isWalletConnected = useSelector(selectIsWalletConnected);
   const isWalletOnVaultChain = useSelector(
     (state: BeefyState) => selectCurrentChainId(state) === vault.chainId
   );

--- a/src/features/vault/components/BoostWidget/Stake/Stake.tsx
+++ b/src/features/vault/components/BoostWidget/Stake/Stake.tsx
@@ -1,12 +1,12 @@
 import {
   Box,
   Button,
-  makeStyles,
-  Typography,
-  IconButton,
   FormControl,
+  IconButton,
   InputAdornment,
   InputBase,
+  makeStyles,
+  Typography,
 } from '@material-ui/core';
 import React from 'react';
 import { useDispatch, useSelector, useStore } from 'react-redux';
@@ -28,6 +28,7 @@ import { boostModalActions } from '../../../../data/reducers/wallet/boost-modal'
 import {
   selectCurrentChainId,
   selectIsWalletConnected,
+  selectIsWalletKnown,
   selectWalletAddress,
 } from '../../../../data/selectors/wallet';
 import { Step } from '../../../../../components/Steps/types';
@@ -61,7 +62,7 @@ export const Stake = ({
       isFulfilled(state.ui.dataLoader.global.boostForm)
   );
   const walletAddress = useSelector((state: BeefyState) =>
-    selectIsWalletConnected(state) ? selectWalletAddress(state) : null
+    selectIsWalletKnown(state) ? selectWalletAddress(state) : null
   );
 
   // initialize our form
@@ -95,7 +96,7 @@ const StakeForm = ({
     selectBoostUserBalanceInToken(state, boost.id)
   );
 
-  const isWalletConnected = useSelector((state: BeefyState) => selectIsWalletConnected(state));
+  const isWalletConnected = useSelector(selectIsWalletConnected);
   const isWalletOnVaultChain = useSelector(
     (state: BeefyState) => selectCurrentChainId(state) === vault.chainId
   );

--- a/src/features/vault/components/BoostWidget/Unstake/Unstake.tsx
+++ b/src/features/vault/components/BoostWidget/Unstake/Unstake.tsx
@@ -1,12 +1,12 @@
 import {
   Box,
   Button,
-  makeStyles,
-  Typography,
-  IconButton,
   FormControl,
+  IconButton,
   InputAdornment,
   InputBase,
+  makeStyles,
+  Typography,
 } from '@material-ui/core';
 import React from 'react';
 import { useDispatch, useSelector, useStore } from 'react-redux';
@@ -24,6 +24,7 @@ import { initBoostForm } from '../../../../data/actions/scenarios';
 import {
   selectCurrentChainId,
   selectIsWalletConnected,
+  selectIsWalletKnown,
   selectWalletAddress,
 } from '../../../../data/selectors/wallet';
 import { BeefyState } from '../../../../../redux-types';
@@ -60,7 +61,7 @@ export const Unstake = ({
       isFulfilled(state.ui.dataLoader.global.boostForm)
   );
   const walletAddress = useSelector((state: BeefyState) =>
-    selectIsWalletConnected(state) ? selectWalletAddress(state) : null
+    selectIsWalletKnown(state) ? selectWalletAddress(state) : null
   );
 
   // initialize our form
@@ -94,7 +95,7 @@ const UnstakeForm = ({
     selectBoostUserBalanceInToken(state, boost.id)
   );
 
-  const isWalletConnected = useSelector((state: BeefyState) => selectIsWalletConnected(state));
+  const isWalletConnected = useSelector(selectIsWalletConnected);
   const isWalletOnVaultChain = useSelector(
     (state: BeefyState) => selectCurrentChainId(state) === vault.chainId
   );

--- a/src/features/vault/components/Deposit/Deposit.tsx
+++ b/src/features/vault/components/Deposit/Deposit.tsx
@@ -48,7 +48,7 @@ export const Deposit = ({ vaultId }: { vaultId: VaultEntity['id'] }) => {
   const { t } = useTranslation();
   const store = useStore();
   const vault = useSelector((state: BeefyState) => selectVaultById(state, vaultId));
-  const isWalletConnected = useSelector((state: BeefyState) => selectIsWalletConnected(state));
+  const isWalletConnected = useSelector(selectIsWalletConnected);
   const isWalletOnVaultChain = useSelector(
     (state: BeefyState) => selectCurrentChainId(state) === vault.chainId
   );

--- a/src/features/vault/components/MinterCards/Cards/beftm/BeFtmCard.tsx
+++ b/src/features/vault/components/MinterCards/Cards/beftm/BeFtmCard.tsx
@@ -31,13 +31,13 @@ import { selectMinterById } from '../../../../../data/selectors/minters';
 const useStyles = makeStyles(styles as any);
 
 // TODO this and SpiritCard minter cards could be refactored out to a common component
-export const BeFtmCard = memo(function BeFtmCard({ vaultId, minterId }: MinterCardParams) {
+export const BeFtmCard = memo<MinterCardParams>(function BeFtmCard({ vaultId, minterId }) {
   const classes = useStyles();
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const vault = useSelector((state: BeefyState) => selectVaultById(state, vaultId));
   const minter = useSelector((state: BeefyState) => selectMinterById(state, minterId));
-  const isWalletConnected = useSelector((state: BeefyState) => selectIsWalletConnected(state));
+  const isWalletConnected = useSelector(selectIsWalletConnected);
   const isWalletOnVaultChain = useSelector(
     (state: BeefyState) => selectCurrentChainId(state) === vault.chainId
   );

--- a/src/features/vault/components/MinterCards/Cards/bejoe/JoeCard.tsx
+++ b/src/features/vault/components/MinterCards/Cards/bejoe/JoeCard.tsx
@@ -10,7 +10,7 @@ import { MinterCardParams } from '../../MinterCard';
 const useStyles = makeStyles(styles as any);
 
 // TODO this and beFTM minter cards could be refactored out to a common component
-export const JoeCard = memo(function JoeCard({ vaultId, minterId }: MinterCardParams) {
+export const JoeCard = memo<MinterCardParams>(function JoeCard({ vaultId, minterId }) {
   const classes = useStyles();
   const { t } = useTranslation();
 

--- a/src/features/vault/components/MinterCards/Cards/bejoe/components/Burn.tsx
+++ b/src/features/vault/components/MinterCards/Cards/bejoe/components/Burn.tsx
@@ -32,13 +32,13 @@ import { selectChainById } from '../../../../../../data/selectors/chains';
 
 const useStyles = makeStyles(styles as any);
 
-export const Burn = memo(function Burn({ vaultId, minterId }: MinterCardParams) {
+export const Burn = memo<MinterCardParams>(function Burn({ vaultId, minterId }) {
   const classes = useStyles();
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const vault = useSelector((state: BeefyState) => selectVaultById(state, vaultId));
   const minter = useSelector((state: BeefyState) => selectMinterById(state, minterId));
-  const isWalletConnected = useSelector((state: BeefyState) => selectIsWalletConnected(state));
+  const isWalletConnected = useSelector(selectIsWalletConnected);
   const isWalletOnVaultChain = useSelector(
     (state: BeefyState) => selectCurrentChainId(state) === vault.chainId
   );

--- a/src/features/vault/components/MinterCards/Cards/bejoe/components/Mint.tsx
+++ b/src/features/vault/components/MinterCards/Cards/bejoe/components/Mint.tsx
@@ -30,13 +30,13 @@ import { selectAllowanceByTokenId } from '../../../../../../data/selectors/allow
 
 const useStyles = makeStyles(styles as any);
 
-export const Mint = memo(function Mint({ vaultId, minterId }: MinterCardParams) {
+export const Mint = memo<MinterCardParams>(function Mint({ vaultId, minterId }) {
   const classes = useStyles();
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const vault = useSelector((state: BeefyState) => selectVaultById(state, vaultId));
   const minter = useSelector((state: BeefyState) => selectMinterById(state, minterId));
-  const isWalletConnected = useSelector((state: BeefyState) => selectIsWalletConnected(state));
+  const isWalletConnected = useSelector(selectIsWalletConnected);
   const isWalletOnVaultChain = useSelector(
     (state: BeefyState) => selectCurrentChainId(state) === vault.chainId
   );

--- a/src/features/vault/components/MinterCards/Cards/binspirit/SpiritCard.tsx
+++ b/src/features/vault/components/MinterCards/Cards/binspirit/SpiritCard.tsx
@@ -32,13 +32,13 @@ import { selectAllowanceByTokenId } from '../../../../../data/selectors/allowanc
 const useStyles = makeStyles(styles as any);
 
 // TODO this and beFTM minter cards could be refactored out to a common component
-export const SpiritCard = memo(function SpiritCard({ vaultId, minterId }: MinterCardParams) {
+export const SpiritCard = memo<MinterCardParams>(function SpiritCard({ vaultId, minterId }) {
   const classes = useStyles();
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const vault = useSelector((state: BeefyState) => selectVaultById(state, vaultId));
   const minter = useSelector((state: BeefyState) => selectMinterById(state, minterId));
-  const isWalletConnected = useSelector((state: BeefyState) => selectIsWalletConnected(state));
+  const isWalletConnected = useSelector(selectIsWalletConnected);
   const isWalletOnVaultChain = useSelector(
     (state: BeefyState) => selectCurrentChainId(state) === vault.chainId
   );

--- a/src/features/vault/components/MinterCards/MinterCard.tsx
+++ b/src/features/vault/components/MinterCards/MinterCard.tsx
@@ -6,7 +6,7 @@ import { BeefyState } from '../../../../redux-types';
 import { selectIsAddressBookLoaded } from '../../../data/selectors/data-loader';
 import { Loader } from '../../../../components/loader';
 import { isFulfilled } from '../../../data/reducers/data-loader';
-import { selectIsWalletConnected, selectWalletAddress } from '../../../data/selectors/wallet';
+import { selectIsWalletKnown, selectWalletAddress } from '../../../data/selectors/wallet';
 import { initMinterForm } from '../../../data/actions/scenarios';
 import { selectMinterById } from '../../../data/selectors/minters';
 
@@ -19,16 +19,16 @@ function importMinterCard(minterId: MinterEntity['id']) {
   return lazy<FC<MinterCardParams>>(() => import(`./Cards/${minterId}`));
 }
 
-const MinterCardImporter = memo(function MinterCardImporter({
+const MinterCardImporter = memo<MinterCardParams>(function MinterCardImporter({
   vaultId,
   minterId,
-}: MinterCardParams) {
+}) {
   const Card = importMinterCard(minterId);
 
   return <Card vaultId={vaultId} minterId={minterId} />;
 });
 
-export const MinterCard = memo(function MinterCard({ vaultId, minterId }: MinterCardParams) {
+export const MinterCard = memo<MinterCardParams>(function MinterCard({ vaultId, minterId }) {
   const minter = useSelector((state: BeefyState) => selectMinterById(state, minterId));
   const isFormReady = useSelector(
     (state: BeefyState) =>
@@ -36,7 +36,7 @@ export const MinterCard = memo(function MinterCard({ vaultId, minterId }: Minter
       isFulfilled(state.ui.dataLoader.global.minterForm)
   );
   const walletAddress = useSelector((state: BeefyState) =>
-    selectIsWalletConnected(state) ? selectWalletAddress(state) : null
+    selectIsWalletKnown(state) ? selectWalletAddress(state) : null
   );
 
   // initialize our form

--- a/src/features/vault/components/Withdraw/Withdraw.tsx
+++ b/src/features/vault/components/Withdraw/Withdraw.tsx
@@ -41,6 +41,7 @@ import { selectVaultById } from '../../../data/selectors/vaults';
 import {
   selectCurrentChainId,
   selectIsWalletConnected,
+  selectIsWalletKnown,
   selectWalletAddress,
 } from '../../../data/selectors/wallet';
 import { selectIsApprovalNeededForWithdraw } from '../../../data/selectors/wallet-actions';
@@ -59,12 +60,12 @@ export const Withdraw = ({ vaultId }: { vaultId: VaultEntity['id'] }) => {
 
   const store = useStore();
   const vault = useSelector((state: BeefyState) => selectVaultById(state, vaultId));
-  const isWalletConnected = useSelector((state: BeefyState) => selectIsWalletConnected(state));
+  const isWalletConnected = useSelector(selectIsWalletConnected);
   const isWalletOnVaultChain = useSelector(
     (state: BeefyState) => selectCurrentChainId(state) === vault.chainId
   );
   const walletAddress = useSelector((state: BeefyState) =>
-    selectIsWalletConnected(state) ? selectWalletAddress(state) : null
+    selectIsWalletKnown(state) ? selectWalletAddress(state) : null
   );
 
   // initialize our form


### PR DESCRIPTION
Link T-544

Using the new selectIsWalletConnected for components that need to initiated wallet transactions so they don't get an error if their wallet didn't reconnect but that app knows their address from the persisted state.

## Renames `selectIsWalletConnected` to `selectIsWalletKnown`.
This returns true if the state knows the users address either through a wallet connection; or because the user is a returning visitor and their address has been hydrated from the persisted state.

## Adds `selectIsWalletConnected`
Additionally checks if the apps wallet has been initialized. 
For returning users whose wallet is still connected (99% of MetaMask users) - wallet will reconnect in a second or two.
For returning users who's wallet is disconnected or locked, this won't return true until the user unlocks/reconnects the wallet.
(Cancelling the unlock/reconnect popup will clear address from state).

(Whoops merged prod in to this branch..)