### PR TITLE
Add redirects from old chain specific urls to home page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { HashRouter as Router, Route, Switch } from 'react-router-dom';
+import { HashRouter as Router, Redirect, Route, Switch } from 'react-router-dom';
 import { Header } from './components/Header';
 import { WrappedFooter } from './components/Footer';
 import { CssBaseline, ThemeProvider } from '@material-ui/core';
@@ -10,6 +10,7 @@ import { store } from './store';
 import { featureFlag_replayReduxActions } from './features/data/utils/feature-flags';
 import { replayReduxActions } from './features/data/middlewares/debug/debug-replay';
 import { CowLoader } from './components/CowLoader';
+import { REDIRECTS } from './config/redirects';
 
 const Home = React.lazy(() => import(`./features/home`));
 const Vault = React.lazy(() => import(`./features/vault`));
@@ -45,12 +46,14 @@ export const App = () => {
               <Route strict sensitive exact path="/:network/vault/:id">
                 <Vault />
               </Route>
-              {/* <Route exact path="/nfts">
-              <BeefyAvatars />
-            </Route> */}
               <Route exact path="/media-kit">
                 <BrandAssets />
               </Route>
+              {REDIRECTS.map(redirect => (
+                <Route key={redirect.from} path={redirect.from} exact={true}>
+                  <Redirect to={redirect.to} />
+                </Route>
+              ))}
               <Route>
                 <PageNotFound />
               </Route>

--- a/src/config/redirects.ts
+++ b/src/config/redirects.ts
@@ -1,0 +1,16 @@
+export const REDIRECTS = [
+  { from: '/bsc', to: '/' },
+  { from: '/heco', to: '/' },
+  { from: '/avax', to: '/' },
+  { from: '/polygon', to: '/' },
+  { from: '/fantom', to: '/' },
+  { from: '/harmony', to: '/' },
+  { from: '/arbitrum', to: '/' },
+  { from: '/celo', to: '/' },
+  { from: '/moonriver', to: '/' },
+  { from: '/cronos', to: '/' },
+  { from: '/fuse', to: '/' },
+  { from: '/metis', to: '/' },
+  { from: '/aurora', to: '/' },
+  { from: '/moonbeam', to: '/' },
+];


### PR DESCRIPTION
Link T-242

Redirects /#/bsc, /#/heco, /#/avax, /#/polygon, /#/fantom, /#/harmony, /#/arbitrum, /#/celo, /#/moonriver, /#/cronos, /#/fuse, /#/metis, /#/aurora and /#/moonbeam to /#/ 

These currently 404 however there may be bookmarks or other incoming links.