### PR TITLE
Don't throw error on deposit if asset does not exist in address book

### DIFF
--- a/src/config/vault/polygon.tsx
+++ b/src/config/vault/polygon.tsx
@@ -5166,7 +5166,7 @@ export const pools = [
     oracleId: 'quick-matic-wcro',
     status: 'active',
     platform: 'QuickSwap',
-    assets: ['CRO', 'MATIC'],
+    assets: ['WCRO', 'MATIC'],
     risks: [
       'COMPLEXITY_LOW',
       'BATTLE_TESTED',

--- a/src/features/data/actions/wallet-actions.tsx
+++ b/src/features/data/actions/wallet-actions.tsx
@@ -32,6 +32,7 @@ import {
   selectChainNativeToken,
   selectChainWrappedNativeToken,
   selectErc20TokenByAddress,
+  selectIsTokenLoaded,
   selectTokenByAddress,
   selectTokenById,
 } from '../selectors/tokens';
@@ -892,7 +893,11 @@ function getVaultTokensToRefresh(state: BeefyState, vault: VaultEntity) {
   // refresh vault tokens
   if (isStandardVault(vault)) {
     for (const assetId of vault.assetIds) {
-      tokens.push(selectTokenById(state, vault.chainId, assetId));
+      // selectTokenById throws if token does not exist;
+      // tokens in assetIds[] might not exist if vault does not have ZAP
+      if (selectIsTokenLoaded(state, vault.chainId, assetId)) {
+        tokens.push(selectTokenById(state, vault.chainId, assetId));
+      }
     }
   }
   tokens.push(selectTokenByAddress(state, vault.chainId, vault.depositTokenAddress));


### PR DESCRIPTION
After a vault TX, all assets in the vault config assets[] array are queued to update the users balance.

Some of these assets do not exist in the address book causing the deposit to throw.

We can check if they exist first to avoid the throw.