### PR TITLE
Use getAmountsOut for BiSwap zap withdraw estimates

### DIFF
--- a/src/config/zap/bsc.tsx
+++ b/src/config/zap/bsc.tsx
@@ -40,5 +40,6 @@ export const zaps = [
     ammRouter: '0x3a6d8cA21D1CF76F653A67577FA0D27453350dD8',
     ammFactory: '0x858E3312ed3A876947EA49d572A7C42DE08af7EE',
     ammPairInitHash: '0xfea293c909d87cd4153593f077b76bb7e94340200f4ee84211ae8e4f9bd7ffdf',
+    withdrawEstimateMode: 'getAmountsOut',
   },
 ];

--- a/src/features/data/apis/config-types.ts
+++ b/src/features/data/apis/config-types.ts
@@ -123,6 +123,7 @@ export interface ZapConfig {
   ammRouter: string;
   ammFactory: string;
   ammPairInitHash: string;
+  withdrawEstimateMode?: 'getAmountOut' | 'getAmountsOut';
 }
 
 export interface MinterConfigTokenErc20 {


### PR DESCRIPTION
BiSwap can have different fees for different pairs, so its `getAmountOut` method requires an additional fourth parameter  (swapFee) compared to other AMMs.

This PR swaps from using `getAmountOut(amountIn,reserveIn,reserveOut)` to `getAmountsOut(amountIn,path[])` for BiSwap only. BiSwap automatically fills in the swap fee via this method.