### PR TITLE
Fix for celo gov earned token race condition

### DIFF
--- a/src/config/vault/celo.tsx
+++ b/src/config/vault/celo.tsx
@@ -9,7 +9,7 @@ export const pools = [
     tokenDecimals: 18,
     tokenDescriptionUrl:
       'https://docs.beefy.finance/moo/ecosystem/bifi-token/tokenomics-and-governance',
-    earnedToken: 'CELO',
+    earnedToken: 'WCELO',
     earnedTokenAddress: '0x471EcE3750Da237f93B8E339c536989b8978a438',
     earnedTokenDecimals: 18,
     earnContractAddress: '0x2D250016E3621CfC50A0ff7e5f6E34bbC6bfE50E',


### PR DESCRIPTION
If addressbook fails to load quickly enough the app lacks the celo token address since it was being added as native, we now get it added as WCELO so we get the token listed in the state if the addressbook fails (it will be loaded from the vault config files)