### PR TITLE
Add avg portfolio apy

### DIFF
--- a/src/components/Bridge/components/Preview/Preview.tsx
+++ b/src/components/Bridge/components/Preview/Preview.tsx
@@ -10,7 +10,7 @@ import {
   selectCurrentChainId,
   selectIsWalletConnected,
 } from '../../../../features/data/selectors/wallet';
-import { BIG_ZERO, formatBigDecimals } from '../../../../helpers/format';
+import { formatBigDecimals } from '../../../../helpers/format';
 import {
   askForNetworkChange,
   askForWalletConnection,
@@ -26,6 +26,7 @@ import { first } from 'lodash';
 import { ChainSelector } from '../ChainSelector';
 import { Button } from '../../../Button';
 import { styles } from './styles';
+import { BIG_ZERO } from '../../../../helpers/big-number';
 
 const useStyles = makeStyles(styles);
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -21,13 +21,14 @@ import {
   selectCurrentChainId,
   selectIsWalletConnected,
 } from '../../features/data/selectors/wallet';
-import { BIG_ZERO, formatBigUsd } from '../../helpers/format';
+import { formatBigUsd } from '../../helpers/format';
 import { BeefyState } from '../../redux-types';
 import { LanguageDropdown } from '../LanguageDropdown';
 import { ChainEntity } from '../../features/data/entities/chain';
 import { NetworkStatus } from '../NetworkStatus';
 import { Transak } from '../Transak';
 import { styles } from './styles';
+import { BIG_ZERO } from '../../helpers/big-number';
 
 // lazy load web3 related stuff, as libs are quite heavy
 const WalletContainer = React.lazy(() => import(`./components/WalletContainer`));

--- a/src/components/VaultTvl/VaultTvl.tsx
+++ b/src/components/VaultTvl/VaultTvl.tsx
@@ -9,9 +9,10 @@ import {
 import { selectIsVaultBoosted } from '../../features/data/selectors/boosts';
 import { selectVaultTvl } from '../../features/data/selectors/tvl';
 import { selectVaultById } from '../../features/data/selectors/vaults';
-import { BIG_ZERO, formatBigUsd } from '../../helpers/format';
+import { formatBigUsd } from '../../helpers/format';
 import { BeefyState } from '../../redux-types';
 import { ValueBlock } from '../ValueBlock/ValueBlock';
+import { BIG_ZERO } from '../../helpers/big-number';
 
 const _VaultTvl = connect((state: BeefyState, { vaultId }: { vaultId: VaultEntity['id'] }) => {
   const vault = selectVaultById(state, vaultId);

--- a/src/features/data/actions/wallet-actions.tsx
+++ b/src/features/data/actions/wallet-actions.tsx
@@ -44,11 +44,12 @@ import { getZapAddress } from '../utils/zap-utils';
 import { reloadBalanceAndAllowanceAndGovRewardsAndBoostData } from './tokens';
 import { getGasPriceOptions } from '../utils/gas-utils';
 import { AbiItem } from 'web3-utils';
-import { BIG_ZERO, convertAmountToRawNumber } from '../../../helpers/format';
+import { convertAmountToRawNumber } from '../../../helpers/format';
 import { FriendlyError } from '../utils/error-utils';
 import { MinterEntity } from '../entities/minter';
 import { reloadReserves } from './minters';
 import { selectChainById } from '../selectors/chains';
+import { BIG_ZERO } from '../../../helpers/big-number';
 
 export const WALLET_ACTION = 'WALLET_ACTION';
 export const WALLET_ACTION_RESET = 'WALLET_ACTION_RESET';

--- a/src/features/data/apis/beefy.ts
+++ b/src/features/data/apis/beefy.ts
@@ -13,7 +13,7 @@ interface ApyGovVault {
 interface ApyMaxiVault {
   totalApy: number;
 }
-interface ApyStandard {
+export interface ApyStandard {
   beefyPerformanceFee: number;
   vaultApr: number;
   compoundingsPerYear: number;

--- a/src/features/data/apis/minter/minter.ts
+++ b/src/features/data/apis/minter/minter.ts
@@ -4,8 +4,8 @@ import { FetchMinterReservesResult, IMinterApi } from './minter-types';
 import { getContract } from '../../../../helpers/getContract';
 import MinterAbi from '../../../../config/abi/minter.json';
 import BigNumber from 'bignumber.js';
-import { BIG_ZERO } from '../../../../helpers/format';
 import { MinterEntity } from '../../entities/minter';
+import { BIG_ZERO } from '../../../../helpers/big-number';
 
 export class MinterApi implements IMinterApi {
   constructor(protected web3: Web3, protected chain: ChainEntity) {}

--- a/src/features/data/apis/zap.ts
+++ b/src/features/data/apis/zap.ts
@@ -6,7 +6,6 @@ import { AbiItem } from 'web3-utils';
 import _uniswapV2PairABI from '../../../config/abi/uniswapV2Pair.json';
 import _uniswapV2RouterABI from '../../../config/abi/uniswapV2Router.json';
 import _zapAbi from '../../../config/abi/zap.json';
-import { BIG_ZERO } from '../../../helpers/format';
 import { BeefyState } from '../../../redux-types';
 import { isTokenErc20, isTokenNative, TokenEntity } from '../entities/token';
 import { isStandardVault, VaultEntity } from '../entities/vault';
@@ -21,6 +20,7 @@ import {
 import { selectVaultById } from '../selectors/vaults';
 import { getZapAddress, getZapDecimals } from '../utils/zap-utils';
 import { getWeb3Instance } from './instances';
+import { BIG_ZERO } from '../../../helpers/big-number';
 
 // fix ts types
 const zapAbi = _zapAbi as AbiItem | AbiItem[];

--- a/src/features/data/reducers/apy.ts
+++ b/src/features/data/reducers/apy.ts
@@ -1,6 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { WritableDraft } from 'immer/dist/internal';
-import { BIG_ONE } from '../../../helpers/format';
 import { BeefyState } from '../../../redux-types';
 import { fetchApyAction } from '../actions/apy';
 import { fetchAllContractDataByChainAction } from '../actions/contract-data';
@@ -23,6 +22,7 @@ import { selectVaultById, selectVaultPricePerFullShare } from '../selectors/vaul
 import { createIdMap } from '../utils/array-utils';
 import { mooAmountToOracleAmount } from '../utils/ppfs';
 import { getBoostStatusFromPeriodFinish } from './boosts';
+import { BIG_ONE } from '../../../helpers/big-number';
 
 // boost is expressed as APR
 interface AprData {

--- a/src/features/data/reducers/tvl.ts
+++ b/src/features/data/reducers/tvl.ts
@@ -1,6 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
 import BigNumber from 'bignumber.js';
-import { BIG_ZERO } from '../../../helpers/format';
 import { mooAmountToOracleAmount } from '../utils/ppfs';
 import { WritableDraft } from 'immer/dist/internal';
 import { fetchAllContractDataByChainAction } from '../actions/contract-data';
@@ -13,6 +12,7 @@ import { FetchAllContractDataResult } from '../apis/contract-data/contract-data-
 import { BeefyState } from '../../../redux-types';
 import { reloadBalanceAndAllowanceAndGovRewardsAndBoostData } from '../actions/tokens';
 import { ChainEntity } from '../entities/chain';
+import { BIG_ZERO } from '../../../helpers/big-number';
 
 /**
  * State containing APY infos indexed by vault id

--- a/src/features/data/reducers/wallet/balance.ts
+++ b/src/features/data/reducers/wallet/balance.ts
@@ -2,7 +2,6 @@ import { createSlice } from '@reduxjs/toolkit';
 import BigNumber from 'bignumber.js';
 import { WritableDraft } from 'immer/dist/internal';
 import { uniq } from 'lodash';
-import { BIG_ZERO } from '../../../../helpers/format';
 import { BeefyState } from '../../../../redux-types';
 import { fetchAllBalanceAction } from '../../actions/balance';
 import { initiateBoostForm } from '../../actions/boosts';
@@ -25,6 +24,7 @@ import {
 import { initiateMinterForm } from '../../actions/minters';
 import { initiateBridgeForm } from '../../actions/bridge';
 import { selectMinterById } from '../../selectors/minters';
+import { BIG_ZERO } from '../../../../helpers/big-number';
 
 /**
  * State containing user balances state

--- a/src/features/data/reducers/wallet/boost-modal.ts
+++ b/src/features/data/reducers/wallet/boost-modal.ts
@@ -1,10 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import BigNumber from 'bignumber.js';
-import {
-  BIG_ZERO,
-  formatBigDecimals,
-  formatBigNumberSignificant,
-} from '../../../../helpers/format';
+import { formatBigDecimals, formatBigNumberSignificant } from '../../../../helpers/format';
 import { BeefyState } from '../../../../redux-types';
 import { initiateBoostForm } from '../../actions/boosts';
 import { BoostEntity } from '../../entities/boost';
@@ -12,6 +8,7 @@ import { selectBoostUserBalanceInToken, selectUserBalanceOfToken } from '../../s
 import { selectBoostById } from '../../selectors/boosts';
 import { selectTokenByAddress } from '../../selectors/tokens';
 import { selectVaultById } from '../../selectors/vaults';
+import { BIG_ZERO } from '../../../../helpers/big-number';
 
 // TODO: this looks exactly like the withdraw state
 export type BoostModalState = {

--- a/src/features/data/reducers/wallet/bridge-modal.ts
+++ b/src/features/data/reducers/wallet/bridge-modal.ts
@@ -1,10 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import BigNumber from 'bignumber.js';
-import {
-  BIG_ZERO,
-  formatBigDecimals,
-  formatBigNumberSignificant,
-} from '../../../../helpers/format';
+import { formatBigDecimals, formatBigNumberSignificant } from '../../../../helpers/format';
 import { BeefyState } from '../../../../redux-types';
 import { fetchBridgeChainData, initiateBridgeForm } from '../../actions/bridge';
 import { BridgeInfoEntity } from '../../apis/bridge/bridge-types';
@@ -13,6 +9,7 @@ import { selectUserBalanceOfToken } from '../../selectors/balance';
 import { selectBridgeBifiDestChainData } from '../../selectors/bridge';
 import { selectChainById } from '../../selectors/chains';
 import { selectTokenByAddress } from '../../selectors/tokens';
+import { BIG_ZERO } from '../../../../helpers/big-number';
 
 type statusType = 'idle' | 'loading' | 'confirming' | 'success';
 

--- a/src/features/data/reducers/wallet/deposit.ts
+++ b/src/features/data/reducers/wallet/deposit.ts
@@ -1,10 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import BigNumber from 'bignumber.js';
-import {
-  BIG_ZERO,
-  formatBigDecimals,
-  formatBigNumberSignificant,
-} from '../../../../helpers/format';
+import { formatBigDecimals, formatBigNumberSignificant } from '../../../../helpers/format';
 import { BeefyState } from '../../../../redux-types';
 import { initiateDepositForm } from '../../actions/deposit';
 import { fetchEstimateZapDeposit } from '../../actions/zap';
@@ -14,6 +10,7 @@ import { VaultEntity } from '../../entities/vault';
 import { selectUserBalanceOfToken } from '../../selectors/balance';
 import { selectTokenByAddress, selectTokenById } from '../../selectors/tokens';
 import { selectVaultById } from '../../selectors/vaults';
+import { BIG_ZERO } from '../../../../helpers/big-number';
 
 // TODO: this looks exactly like the withdraw state
 export type DepositState = {

--- a/src/features/data/reducers/wallet/withdraw.ts
+++ b/src/features/data/reducers/wallet/withdraw.ts
@@ -1,11 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import BigNumber from 'bignumber.js';
 import { isArray } from 'lodash';
-import {
-  BIG_ZERO,
-  formatBigDecimals,
-  formatBigNumberSignificant,
-} from '../../../../helpers/format';
+import { formatBigDecimals, formatBigNumberSignificant } from '../../../../helpers/format';
 import { BeefyState } from '../../../../redux-types';
 import { initiateWithdrawForm } from '../../actions/withdraw';
 import { fetchEstimateZapWithdraw } from '../../actions/zap';
@@ -20,6 +16,7 @@ import {
 import { selectTokenByAddress, selectTokenById } from '../../selectors/tokens';
 import { selectVaultById, selectVaultPricePerFullShare } from '../../selectors/vaults';
 import { mooAmountToOracleAmount } from '../../utils/ppfs';
+import { BIG_ZERO } from '../../../../helpers/big-number';
 
 // TODO: this looks exactly like the deposit state
 export type WithdrawState = {

--- a/src/features/data/selectors/allowances.ts
+++ b/src/features/data/selectors/allowances.ts
@@ -1,7 +1,7 @@
-import { BIG_ZERO } from '../../../helpers/format';
 import { BeefyState } from '../../../redux-types';
 import { ChainEntity } from '../entities/chain';
 import { TokenEntity } from '../entities/token';
+import { BIG_ZERO } from '../../../helpers/big-number';
 
 export const selectAllowanceByTokenAddress = (
   state: BeefyState,

--- a/src/features/data/selectors/apy.ts
+++ b/src/features/data/selectors/apy.ts
@@ -1,7 +1,6 @@
-import { BIG_ZERO } from '../../../helpers/format';
 import { BeefyState } from '../../../redux-types';
-import { isGovVaultApy, isMaxiVaultApy, isStandardVaultApy } from '../apis/beefy';
-import { isGovVault, VaultEntity, VaultGov, VaultStandard } from '../entities/vault';
+import { ApyStandard, isGovVaultApy } from '../apis/beefy';
+import { isGovVault, isVaultActive, VaultEntity, VaultGov, VaultStandard } from '../entities/vault';
 import {
   selectGovVaultUserStackedBalanceInDepositToken,
   selectStandardVaultUserBalanceInDepositTokenIncludingBoosts,
@@ -10,6 +9,7 @@ import {
 import { selectIsUserBalanceAvailable } from './data-loader';
 import { selectTokenPriceByAddress } from './tokens';
 import { selectVaultById } from './vaults';
+import { BIG_ZERO, compound } from '../../../helpers/big-number';
 
 const selectGovVaultRawApr = (state: BeefyState, vaultId: VaultGov['id']) => {
   const vaultApy = state.biz.apy.rawApy.byVaultId[vaultId];
@@ -22,15 +22,15 @@ const selectGovVaultRawApr = (state: BeefyState, vaultId: VaultGov['id']) => {
   return vaultApy.vaultApr;
 };
 
-const selectStandardVaultRawTotalApy = (state: BeefyState, vaultId: VaultStandard['id']) => {
-  const vaultApy = state.biz.apy.rawApy.byVaultId[vaultId];
-  if (vaultApy === undefined) {
-    return 0;
+const selectStandardVaultRawApy = (
+  state: BeefyState,
+  vaultId: VaultStandard['id']
+): Partial<ApyStandard> => {
+  const apyData = state.biz.apy.rawApy.byVaultId[vaultId];
+  if (apyData === undefined) {
+    return { totalApy: 0 };
   }
-  if (!isStandardVaultApy(vaultApy) && !isMaxiVaultApy(vaultApy)) {
-    throw new Error('Apy is not a standard vault apy and not a maxi vault apy');
-  }
-  return vaultApy.totalApy;
+  return apyData;
 };
 
 export const selectVaultTotalApy = (state: BeefyState, vaultId: VaultEntity['id']) => {
@@ -42,11 +42,12 @@ export const selectDidAPIReturnValuesForVault = (state: BeefyState, vaultId: Vau
 };
 
 export const selectUserGlobalStats = (state: BeefyState) => {
-  let newGlobalStats = {
+  const newGlobalStats = {
     deposited: BIG_ZERO,
-    totalYield: BIG_ZERO,
     daily: BIG_ZERO,
     monthly: BIG_ZERO,
+    yearly: BIG_ZERO,
+    apy: BIG_ZERO,
   };
 
   // while loading all necessary data, return 0
@@ -58,31 +59,87 @@ export const selectUserGlobalStats = (state: BeefyState) => {
     selectVaultById(state, vaultId)
   );
 
+  const dailyYield = [];
+
   for (const vault of userVaults) {
     const oraclePrice = selectTokenPriceByAddress(state, vault.chainId, vault.depositTokenAddress);
-    // TODO: this looks suspisciously wrong for gov vaults
     const tokenBalance = isGovVault(vault)
       ? selectGovVaultUserStackedBalanceInDepositToken(state, vault.id)
       : selectStandardVaultUserBalanceInDepositTokenIncludingBoosts(state, vault.id);
     const vaultUsdBalance = tokenBalance.times(oraclePrice);
 
-    // add vault balance to total
+    // Add vault balance to total
     newGlobalStats.deposited = newGlobalStats.deposited.plus(vaultUsdBalance);
 
-    // compute apy and daily yield
+    // Skip non-active/empty vaults for yields
+    if (!isVaultActive(vault) || vaultUsdBalance.lte(BIG_ZERO)) {
+      continue;
+    }
+
+    // Collect yield for each vault
     if (isGovVault(vault)) {
       const apr = selectGovVaultRawApr(state, vault.id);
-      const dailyApr = apr / 365;
-      const dailyUsd = vaultUsdBalance.times(dailyApr);
 
-      newGlobalStats.daily = newGlobalStats.daily.plus(dailyUsd);
+      dailyYield.push({
+        id: vault.id,
+        deposit: vaultUsdBalance,
+        rate: apr / 365,
+        compoundable: false,
+      });
     } else {
-      const apy = selectStandardVaultRawTotalApy(state, vault.id);
-      const dailyApr = Math.pow(10, Math.log10(apy + 1) / 365) - 1;
-      const dailyUsd = vaultUsdBalance.times(dailyApr);
-      newGlobalStats.daily = newGlobalStats.daily.plus(dailyUsd);
+      const apyData = selectStandardVaultRawApy(state, vault.id);
+      // If no tradingApr returned from API, we assume there is no trading component
+      const tradingApr = 'tradingApr' in apyData ? apyData.tradingApr || 0 : 0;
+      // If no vaultApr returned from API, we assume totalApy is all from vault, and not trading
+      const vaultApr =
+        'vaultApr' in apyData
+          ? apyData.vaultApr || 0
+          : (Math.pow((apyData.totalApy || 0) + 1, 1 / 365) - 1) * 365;
+
+      // Trading APR is not compoundable
+      if (tradingApr > 0) {
+        dailyYield.push({
+          id: vault.id,
+          deposit: vaultUsdBalance,
+          rate: tradingApr / 365,
+          compoundable: false,
+        });
+      }
+
+      // Vault APR is compoundable
+      if (vaultApr > 0) {
+        dailyYield.push({
+          id: vault.id,
+          deposit: vaultUsdBalance,
+          rate: vaultApr / 365,
+          compoundable: true,
+        });
+      }
     }
   }
-  newGlobalStats.monthly = newGlobalStats.daily.times(30);
+
+  // Skip yield calc if user has no deposits
+  if (!newGlobalStats.deposited.gt(BIG_ZERO)) {
+    return newGlobalStats;
+  }
+
+  // Compute yield
+  for (const entry of dailyYield) {
+    const daily = entry.deposit.times(entry.rate);
+    const monthly = entry.compoundable
+      ? compound(entry.rate, entry.deposit, 1, 30)
+      : entry.deposit.times(entry.rate).times(30);
+    const yearly = entry.compoundable
+      ? compound(entry.rate, entry.deposit, 1, 365)
+      : entry.deposit.times(entry.rate).times(365);
+
+    newGlobalStats.daily = newGlobalStats.daily.plus(daily);
+    newGlobalStats.monthly = newGlobalStats.monthly.plus(monthly);
+    newGlobalStats.yearly = newGlobalStats.yearly.plus(yearly);
+  }
+
+  // Compute average apy
+  newGlobalStats.apy = newGlobalStats.yearly.dividedBy(newGlobalStats.deposited);
+
   return newGlobalStats;
 };

--- a/src/features/data/selectors/balance.ts
+++ b/src/features/data/selectors/balance.ts
@@ -1,4 +1,3 @@
-import { BIG_ZERO } from '../../../helpers/format';
 import { mooAmountToOracleAmount } from '../utils/ppfs';
 import { BeefyState } from '../../../redux-types';
 import { BoostEntity } from '../entities/boost';
@@ -9,6 +8,7 @@ import { selectActiveVaultBoostIds, selectAllVaultBoostIds, selectBoostById } fr
 import { selectTokenByAddress, selectTokenPriceByAddress } from './tokens';
 import { selectStandardVaultById, selectVaultById, selectVaultPricePerFullShare } from './vaults';
 import { selectIsWalletKnown, selectWalletAddress } from './wallet';
+import { BIG_ZERO } from '../../../helpers/big-number';
 
 const _selectWalletBalance = (state: BeefyState, walletAddress?: string) => {
   if (selectIsWalletKnown(state)) {

--- a/src/features/data/selectors/buyback.ts
+++ b/src/features/data/selectors/buyback.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit';
-import { BIG_ZERO } from '../../../helpers/format';
 import { BeefyState } from '../../../redux-types';
+import { BIG_ZERO } from '../../../helpers/big-number';
 
 export const selectTotalBuybackUsdAmount = createSelector(
   (state: BeefyState) => state.biz.buyback.byChainId,

--- a/src/features/data/selectors/tokens.ts
+++ b/src/features/data/selectors/tokens.ts
@@ -1,9 +1,9 @@
-import { BIG_ONE } from '../../../helpers/format';
 import { bluechipTokens } from '../../../helpers/utils';
 import { BeefyState } from '../../../redux-types';
 import { ChainEntity } from '../entities/chain';
 import { isTokenErc20, isTokenNative, TokenEntity } from '../entities/token';
 import { selectChainById } from './chains';
+import { BIG_ONE } from '../../../helpers/big-number';
 
 export const selectIsTokenLoaded = (
   state: BeefyState,

--- a/src/features/data/selectors/tvl.ts
+++ b/src/features/data/selectors/tvl.ts
@@ -1,6 +1,6 @@
 import { VaultEntity } from '../entities/vault';
 import { BeefyState } from '../../../redux-types';
-import { BIG_ZERO } from '../../../helpers/format';
+import { BIG_ZERO } from '../../../helpers/big-number';
 
 export const selectVaultTvl = (state: BeefyState, vaultId: VaultEntity['id']) =>
   state.biz.tvl.byVaultId[vaultId]?.tvl || BIG_ZERO;

--- a/src/features/data/selectors/vaults.ts
+++ b/src/features/data/selectors/vaults.ts
@@ -1,5 +1,4 @@
 import { createSelector } from '@reduxjs/toolkit';
-import { BIG_ONE } from '../../../helpers/format';
 import { BeefyState } from '../../../redux-types';
 import { ChainEntity } from '../entities/chain';
 import { TokenEntity } from '../entities/token';
@@ -13,6 +12,7 @@ import {
 } from '../entities/vault';
 import { selectIsBeefyToken, selectIsTokenBluechip, selectIsTokenStable } from './tokens';
 import { createCachedSelector } from 're-reselect';
+import { BIG_ONE } from '../../../helpers/big-number';
 
 export const selectVaultById = createCachedSelector(
   (state: BeefyState) => state.entities.vaults.byId,

--- a/src/features/home/components/Portfolio/Stats/Stats.tsx
+++ b/src/features/home/components/Portfolio/Stats/Stats.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import { Box, Grid, Hidden, makeStyles } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
-import { BIG_ZERO, formatUsd } from '../../../../../helpers/format';
+import { formatApy, formatUsd } from '../../../../../helpers/format';
 import { styles } from './styles';
+import { BIG_ZERO } from '../../../../../helpers/big-number';
 
 const useStyles = makeStyles(styles);
 
@@ -40,6 +41,12 @@ export const Stats = ({ stats, blurred }) => {
           <div className={classes.label}>{t('Portfolio-YieldDay')}</div>
           <div className={classes.value}>
             <BlurredText value={formatStat(stats.daily)} />
+          </div>
+        </Box>
+        <Box className={classes.stat}>
+          <div className={classes.label}>{t('Portfolio-AvgAPY')}</div>
+          <div className={classes.value}>
+            <BlurredText value={formatApy(stats.apy.toNumber(), 2, '0%')} />
           </div>
         </Box>
       </Hidden>

--- a/src/features/home/components/Portfolio/styles.tsx
+++ b/src/features/home/components/Portfolio/styles.tsx
@@ -9,7 +9,7 @@ export const styles = theme => ({
     rowGap: '32px',
     columnGap: '32px',
     [theme.breakpoints.up('md')]: {
-      gridTemplateColumns: 'repeat(2, 1fr)',
+      gridTemplateColumns: '583fr 417fr',
     },
   },
   userStats: {},

--- a/src/features/vault/components/MinterCards/MintBurnCard/components/Burn.tsx
+++ b/src/features/vault/components/MinterCards/MintBurnCard/components/Burn.tsx
@@ -5,11 +5,7 @@ import { CardContent } from '../../../Card';
 import { AssetsImage } from '../../../../../../components/AssetsImage';
 import { styles } from '../styles';
 import BigNumber from 'bignumber.js';
-import {
-  BIG_ZERO,
-  formatBigDecimals,
-  formatBigNumberSignificant,
-} from '../../../../../../helpers/format';
+import { formatBigDecimals, formatBigNumberSignificant } from '../../../../../../helpers/format';
 import { selectVaultById } from '../../../../../data/selectors/vaults';
 import { selectUserBalanceOfToken } from '../../../../../data/selectors/balance';
 import {
@@ -28,6 +24,7 @@ import { selectAllowanceByTokenAddress } from '../../../../../data/selectors/all
 import { selectChainById } from '../../../../../data/selectors/chains';
 import { AlertWarning } from '../../../../../../components/Alerts';
 import { useAppDispatch, useAppSelector } from '../../../../../../store';
+import { BIG_ZERO } from '../../../../../../helpers/big-number';
 
 const useStyles = makeStyles(styles);
 

--- a/src/features/vault/components/MinterCards/MintBurnCard/components/Mint.tsx
+++ b/src/features/vault/components/MinterCards/MintBurnCard/components/Mint.tsx
@@ -5,11 +5,7 @@ import { CardContent } from '../../../Card';
 import { AssetsImage } from '../../../../../../components/AssetsImage';
 import { styles } from '../styles';
 import BigNumber from 'bignumber.js';
-import {
-  BIG_ZERO,
-  formatBigDecimals,
-  formatBigNumberSignificant,
-} from '../../../../../../helpers/format';
+import { formatBigDecimals, formatBigNumberSignificant } from '../../../../../../helpers/format';
 import { selectVaultById } from '../../../../../data/selectors/vaults';
 import { selectUserBalanceOfToken } from '../../../../../data/selectors/balance';
 import {
@@ -30,6 +26,7 @@ import { selectMinterById } from '../../../../../data/selectors/minters';
 import { selectAllowanceByTokenAddress } from '../../../../../data/selectors/allowances';
 import { selectChainById } from '../../../../../data/selectors/chains';
 import { useAppDispatch, useAppSelector } from '../../../../../../store';
+import { BIG_ZERO } from '../../../../../../helpers/big-number';
 
 const useStyles = makeStyles(styles);
 

--- a/src/features/vault/components/Withdraw/Withdraw.tsx
+++ b/src/features/vault/components/Withdraw/Withdraw.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { AssetsImage } from '../../../../components/AssetsImage';
 import { useStepper } from '../../../../components/Steps/hooks';
 import { Step } from '../../../../components/Steps/types';
-import { BIG_ZERO, formatBigNumberSignificant } from '../../../../helpers/format';
+import { formatBigNumberSignificant } from '../../../../helpers/format';
 import { initWithdrawForm } from '../../../data/actions/scenarios';
 import { askForNetworkChange, askForWalletConnection } from '../../../data/actions/wallet';
 import { walletActions } from '../../../data/actions/wallet-actions';
@@ -60,6 +60,7 @@ import { TokenWithDeposit } from '../TokenWithDeposit';
 import { EmeraldGasNotice } from '../EmeraldGasNotice/EmeraldGasNotice';
 import { useAppDispatch, useAppSelector, useAppStore } from '../../../../store';
 import { ScreamAvailableLiquidity } from '../ScreamAvailableLiquidity';
+import { BIG_ZERO } from '../../../../helpers/big-number';
 
 const useStyles = makeStyles(styles);
 

--- a/src/helpers/big-number.ts
+++ b/src/helpers/big-number.ts
@@ -1,0 +1,25 @@
+import { BigNumber } from 'bignumber.js';
+
+export type BigNumberish = BigNumber.Value;
+
+export const BIG_ZERO = new BigNumber(0);
+export const BIG_ONE = new BigNumber(1);
+
+export function compound(
+  rate: BigNumberish,
+  principal: BigNumberish = BIG_ONE,
+  periods: number = 365,
+  times: number = 1
+): BigNumber {
+  return toBigNumber(principal)
+    .times(BIG_ONE.plus(toBigNumber(rate).dividedBy(periods)).exponentiatedBy(periods * times))
+    .minus(principal);
+}
+
+export function toBigNumber(input: BigNumberish): BigNumber {
+  if (BigNumber.isBigNumber(input)) {
+    return input;
+  }
+
+  return new BigNumber(input);
+}

--- a/src/helpers/format.tsx
+++ b/src/helpers/format.tsx
@@ -23,9 +23,6 @@ export function formatBigNumberSignificant(num: BigNumber, digits = 6) {
   return `${wholes}.${decimals.match(pattern)[0]}`;
 }
 
-export const BIG_ZERO = new BigNumber(0);
-export const BIG_ONE = new BigNumber(1);
-
 export const formatApy = (apy, dp = 2, placeholder: any = '?') => {
   if (!apy) return placeholder;
 

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -32,6 +32,7 @@
   "Portfolio-YieldTot": "Total yield",
   "Portfolio-YieldDay": "Daily yield",
   "Portfolio-YieldMnth": "Monthly yield",
+  "Portfolio-AvgAPY": "Avg. APY",
   "PortfolioItem-Balance": "Balance",
   "PortfolioItem-Deposits": "Deposits",
   "PortfolioItem-Yield": "Yield",


### PR DESCRIPTION
- Adds estimated APY for whole portfolio
- Removes inactive/paused vaults from displayed yield
- Compounds only vaultApr part of yield (previously totalApy was compounded)
- Month is 30 days compounded (previously 30 days not compounded)

Link T-566