### PR TITLE
Add Aave v3 LINK.e

### DIFF
--- a/src/config/vault/avax.json
+++ b/src/config/vault/avax.json
@@ -5750,5 +5750,40 @@
     "createdAt": 1646787205,
     "network": "avax",
     "retireReason": "rewards"
+  },
+  {
+    "id": "aavev3-link.e",
+    "logo": "single-assets/LINKe.png",
+    "name": "LINK.e",
+    "token": "LINK.e",
+    "tokenDescription": "Aave",
+    "tokenDecimals": 8,
+    "tokenDescriptionUrl": "#",
+    "earnedToken": "mooAaveLINK.e",
+    "earnedTokenAddress": "0x49cBd37fb87312C506fF84c7585A401C4377dDeD",
+    "earnContractAddress": "0x49cBd37fb87312C506fF84c7585A401C4377dDeD",
+    "pricePerFullShare": 1,
+    "tvl": 0,
+    "oracle": "tokens",
+    "oracleId": "LINK.e",
+    "oraclePrice": 0,
+    "depositsPaused": false,
+    "status": "active",
+    "platform": "Aave",
+    "assets": ["LINKe"],
+    "withdrawalFee": "0.01%",
+    "risks": [
+      "COMPLEXITY_MID",
+      "BATTLE_TESTED",
+      "IL_NONE",
+      "MCAP_LARGE",
+      "PLATFORM_ESTABLISHED",
+      "AUDIT",
+      "CONTRACTS_VERIFIED"
+    ],
+    "stratType": "Lending",
+    "buyTokenUrl": "https://www.traderjoexyz.com/trade?outputCurrency=0x5947BB275c521040051D82396192181b413227A3",
+    "createdAt": 1654522324,
+    "network": "avax"
   }
 ]


### PR DESCRIPTION
Adds Aave Avalanche v3 LINK.e. API is deployed already.

Vault: [0x49cBd37fb87312C506fF84c7585A401C4377dDeD](https://snowtrace.io/address/0x49cbd37fb87312c506ff84c7585a401c4377dded)
Strategy: [0x0E6470E890A67c7BCdB818A9724d7E4E60716840](https://snowtrace.io/address/0x0E6470E890A67c7BCdB818A9724d7E4E60716840)