### PR TITLE
EOL 27 vaults

### DIFF
--- a/src/config/vault/avax.json
+++ b/src/config/vault/avax.json
@@ -468,7 +468,8 @@
     "oracle": "lps",
     "oracleId": "joe-bnb-wavax",
     "oraclePrice": 0,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Trader Joe",
     "assets": ["BNB", "AVAX"],
     "risks": [
@@ -501,7 +502,8 @@
     "oracle": "lps",
     "oracleId": "joe-link.e-wavax",
     "oraclePrice": 0,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Trader Joe",
     "assets": ["LINKe", "AVAX"],
     "risks": [
@@ -1244,7 +1246,8 @@
     "oracle": "lps",
     "oracleId": "joe-cra-wavax",
     "oraclePrice": 0,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Trader Joe",
     "assets": ["CRA", "AVAX"],
     "risks": [
@@ -1311,7 +1314,8 @@
     "oracle": "lps",
     "oracleId": "joe-gohm-wavax",
     "oraclePrice": 0,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Trader Joe",
     "assets": ["gOHM", "AVAX"],
     "risks": [
@@ -2399,7 +2403,8 @@
     "oracleId": "joe-wavax-xava",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Trader Joe",
     "assets": ["XAVA", "AVAX"],
     "risks": [
@@ -2433,7 +2438,8 @@
     "oracleId": "joe-wavax-dcau",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Trader Joe",
     "assets": ["DCAU", "AVAX"],
     "risks": [
@@ -3571,7 +3577,8 @@
     "oracleId": "joe-deg-wavax",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Trader Joe",
     "assets": ["DEG", "AVAX"],
     "risks": [
@@ -3849,7 +3856,8 @@
     "oracleId": "joe-ape-wavax",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Trader Joe",
     "assets": ["APE", "AVAX"],
     "risks": [
@@ -4160,7 +4168,8 @@
     "oracleId": "joe-money-wavax",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Trader Joe",
     "assets": ["MONEY", "AVAX"],
     "risks": [
@@ -4438,7 +4447,8 @@
     "oracleId": "joe-lost-wavax",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Trader Joe",
     "assets": ["LOST", "AVAX"],
     "risks": [

--- a/src/config/vault/bsc.json
+++ b/src/config/vault/bsc.json
@@ -413,7 +413,8 @@
     "oracle": "lps",
     "oracleId": "cakev2-rusd-busd",
     "oraclePrice": 0,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "PancakeSwap",
     "assets": ["rUSD", "BUSD"],
     "risks": [

--- a/src/config/vault/cronos.json
+++ b/src/config/vault/cronos.json
@@ -732,7 +732,8 @@
     "oracle": "lps",
     "oracleId": "vvs-cro-dai",
     "oraclePrice": 0,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "VVS",
     "assets": ["CRO", "DAI"],
     "risks": [

--- a/src/config/vault/fantom.json
+++ b/src/config/vault/fantom.json
@@ -2048,7 +2048,8 @@
     "oracle": "lps",
     "oracleId": "boo-wftm-joe",
     "oraclePrice": 0,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "SpookySwap",
     "assets": ["JOE", "FTM"],
     "risks": [
@@ -2215,7 +2216,8 @@
     "oracleId": "boo-wftm-ooe",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "SpookySwap",
     "assets": ["OOE", "FTM"],
     "risks": [
@@ -6219,7 +6221,8 @@
     "oracleId": "tomb-tomb-mai",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Tomb",
     "assets": ["TOMB", "MAI"],
     "risks": [
@@ -6324,7 +6327,8 @@
     "oracleId": "based-based-mai",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Other",
     "assets": ["BASED", "MAI"],
     "risks": [
@@ -7001,7 +7005,8 @@
     "oracleId": "tomb-tshare-mai",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Tomb",
     "assets": ["TSHARE", "MAI"],
     "risks": [
@@ -8875,7 +8880,8 @@
     "oracleId": "tomb-usdc-mai",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Tomb",
     "assets": ["MAI", "USDC"],
     "risks": [

--- a/src/config/vault/metis.json
+++ b/src/config/vault/metis.json
@@ -53,7 +53,8 @@
     "oracleId": "netswap-nett-m.usdt",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Netswap",
     "assets": ["mUSDT", "NETT"],
     "risks": [
@@ -121,7 +122,8 @@
     "oracleId": "netswap-nett-m.usdc",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Netswap",
     "assets": ["mUSDC", "NETT"],
     "risks": [
@@ -155,7 +157,8 @@
     "oracleId": "netswap-weth-nett",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Netswap",
     "assets": ["WETH", "NETT"],
     "risks": [
@@ -530,7 +533,8 @@
     "oracleId": "netswap-wbtc-metis",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Netswap",
     "assets": ["WBTC", "METIS"],
     "risks": [
@@ -564,7 +568,8 @@
     "oracleId": "netswap-wbtc-m.usdt",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Netswap",
     "assets": ["WBTC", "mUSDT"],
     "risks": [

--- a/src/config/vault/moonbeam.json
+++ b/src/config/vault/moonbeam.json
@@ -647,7 +647,8 @@
     "oracleId": "stellaswap-stella-usdc",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Stellaswap",
     "assets": ["STELLA", "USDC"],
     "risks": [
@@ -682,7 +683,8 @@
     "oracleId": "stellaswap-usdc-wglmr",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Stellaswap",
     "assets": ["USDC", "GLMR"],
     "risks": [
@@ -858,7 +860,8 @@
     "oracleId": "stellaswap-usdc-eth",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Stellaswap",
     "assets": ["USDC", "ETH"],
     "risks": [
@@ -893,7 +896,8 @@
     "oracleId": "stellaswap-wglmr-eth",
     "oraclePrice": 0,
     "depositsPaused": false,
-    "status": "active",
+    "status": "eol",
+    "retireReason": "rewards",
     "platform": "Stellaswap",
     "assets": ["GLMR", "ETH"],
     "risks": [


### PR DESCRIPTION
EOL following vaults for rewards ended with no new farms:

moonbeam
	stellaswap-stella-usdc 
	stellaswap-usdc-wglmr  
	stellaswap-usdc-eth    
	stellaswap-wglmr-eth   
metis
	netswap-nett-m.usdt 
	netswap-nett-m.usdc 
	netswap-weth-nett   
	netswap-wbtc-metis  
	netswap-wbtc-m.usdt 
fantom
	boo-wftm-joe    
	boo-wftm-ooe 
	based-based-mai
	tomb-usdc-mai 
	tomb-tomb-mai 
	tomb-tshare-mai
cronos
	vvs-cro-dai
avax
	joe-bnb-wavax    
	joe-link.e-wavax 
	joe-cra-wavax    
	joe-gohm-wavax   
	joe-wavax-xava   
	joe-wavax-dcau   
	joe-deg-wavax    
	joe-ape-wavax    
	joe-money-wavax  
	joe-lost-wavax   
bsc
	cakev2-rusd-busd 