### PR TITLE
Update addLiquidityUrl and buyTokenUrl for hector-tor-crv vault

### DIFF
--- a/src/config/vault/fantom.json
+++ b/src/config/vault/fantom.json
@@ -7351,8 +7351,8 @@
       "ALGO_STABLE"
     ],
     "withdrawalFee": "0%",
-    "addLiquidityUrl": "https://app.hector.finance/#/farming",
-    "buyTokenUrl": "https://app.hector.finance/#/dex",
+    "addLiquidityUrl": "https://app.hector.finance/farm",
+    "buyTokenUrl": "https://app.hector.finance/exchange",
     "createdAt": 1650149559,
     "network": "fantom"
   },


### PR DESCRIPTION
Hector released and new app and changed their routing, so the current links on the vault go to the wrong place now.

This fixes the links so they'll take users to the right place.