### PR TITLE
Fix: bug on long aseets names  in deposit/withdraw  section 

### DIFF
--- a/src/features/vault/components/TokenWithBalance/TokenWithBalance.tsx
+++ b/src/features/vault/components/TokenWithBalance/TokenWithBalance.tsx
@@ -38,7 +38,7 @@ export function TokenWithBalance({
           size={variant === 'sm' ? 20 : 24}
         />
       </Box>
-      <Box flexGrow={1} pl={1} lineHeight={0}>
+      <Box flexGrow={1} pl={1}>
         <div className={classes.assetCount}>
           {formatBigDecimals(balance, 8)} {token.symbol}
         </div>

--- a/src/features/vault/components/TokenWithDeposit/TokenWithDeposit.tsx
+++ b/src/features/vault/components/TokenWithDeposit/TokenWithDeposit.tsx
@@ -95,7 +95,7 @@ export function TokenWithDeposit({
           size={variant === 'sm' ? 20 : 24}
         />
       </Box>
-      <Box flexGrow={1} pl={1} lineHeight={0}>
+      <Box flexGrow={1} pl={1}>
         <div className={classes.assetCount}>
           {intersperse(
             amountsAndSymbol.map(([amount, symbol]) => (


### PR DESCRIPTION
Before 
<img width="334" alt="image" src="https://user-images.githubusercontent.com/88328748/177227081-09391b97-b026-4203-bc8d-38146f6615f3.png">
After 
<img width="340" alt="image" src="https://user-images.githubusercontent.com/88328748/177227100-0dd0de66-8a85-44be-9065-dc467485c082.png">
