### PR TITLE
[UPDATE] Hex for disabled text

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -120,7 +120,7 @@ const theme = createTheme({
     text: {
       primary: '#F5F5FF',
       secondary: '#D0D0DA',
-      disabled: '#8A8EA8',
+      disabled: '#999CB3',
     },
   },
   typography: {


### PR DESCRIPTION
move from ```#8A8EA8``` --> ```#999CB3``` to match with figma 