### PR TITLE
Fix: Solarbeam zap withdraw

### DIFF
--- a/src/config/abi/uniswapV2Router.json
+++ b/src/config/abi/uniswapV2Router.json
@@ -83,6 +83,18 @@
   },
   {
     "inputs": [
+      { "internalType": "uint256", "name": "amountIn", "type": "uint256" },
+      { "internalType": "uint256", "name": "reserveIn", "type": "uint256" },
+      { "internalType": "uint256", "name": "reserveOut", "type": "uint256" },
+      { "internalType": "uint256", "name": "fee", "type": "uint256" }
+    ],
+    "name": "getAmountOut",
+    "outputs": [{ "internalType": "uint256", "name": "amountOut", "type": "uint256" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
       { "internalType": "uint256", "name": "amountOut", "type": "uint256" },
       { "internalType": "address[]", "name": "path", "type": "address[]" }
     ],

--- a/src/config/zap/moonriver.tsx
+++ b/src/config/zap/moonriver.tsx
@@ -5,6 +5,8 @@ export const zaps = [
     ammRouter: '0xAA30eF758139ae4a7f798112902Bf6d65612045f',
     ammFactory: '0x049581aEB6Fe262727f290165C29BDAB065a1B68',
     ammPairInitHash: '0x9a100ded5f254443fbd264cb7e87831e398a8b642e061670a9bc35ba27293dbf',
+    withdrawEstimateMode: 'getAmountOutWithFee',
+    withdrawEstimateFee: '25',
     lpProviderFee: 0.0025,
   },
   {

--- a/src/features/data/apis/config-types.ts
+++ b/src/features/data/apis/config-types.ts
@@ -119,7 +119,8 @@ export interface ZapConfig {
   ammRouter: string;
   ammFactory: string;
   ammPairInitHash: string;
-  withdrawEstimateMode?: 'getAmountOut' | 'getAmountsOut';
+  withdrawEstimateMode?: 'getAmountOut' | 'getAmountsOut' | 'getAmountOutWithFee';
+  withdrawEstimateFee?: string;
   lpProviderFee: number;
 }
 


### PR DESCRIPTION
Need to pass fee as last parameter to `getAmountOut`.

Fee is hardcoded in router as `25`.

Added new `withdrawEstimateMode` mode of `getAmountOutWithFee` and new zap config variable `withdrawEstimateFee`

(Can't use recently added `lpProviderFee` as that is a percent and we don't know what the denominator was)