### PR TITLE
Fix sushi polygon boost ids

### DIFF
--- a/src/config/boost/polygon.json
+++ b/src/config/boost/polygon.json
@@ -99,7 +99,7 @@
   },
   {
     "id": "moo_bifi-usdc-cafe",
-    "poolId": "sushi-usdc-bifi",
+    "poolId": "sushi-poly-usdc-bifi",
     "name": "CafeSwap",
     "assets": ["BIFI", "USDC"],
     "earnedToken": "pBREW",
@@ -403,7 +403,7 @@
   },
   {
     "id": "moo_sushi-jrt-eth-jarvis",
-    "poolId": "sushi-jrt-eth-eol",
+    "poolId": "sushi-poly-jrt-eth-eol",
     "name": "Jarvis",
     "assets": ["JRT", "ETH"],
     "earnedToken": "JRT-ETH-KPI",

--- a/src/config/config.tsx
+++ b/src/config/config.tsx
@@ -114,7 +114,7 @@ export const config = {
   polygon: {
     name: 'Polygon',
     chainId: 137,
-    rpc: ['https://rpc.ankr.com/polygon'],
+    rpc: ['https://polygon-rpc.com'],
     explorerUrl: 'https://polygonscan.com',
     multicallAddress: '0xC3821F0b56FA4F4794d5d760f94B812DE261361B',
     fetchContractDataAddress: '0x9e369f477F2009394D947ea7571b1E6582Bb0511',
@@ -128,7 +128,7 @@ export const config = {
         symbol: 'MATIC',
         decimals: 18,
       },
-      rpcUrls: ['https://rpc.ankr.com/polygon'],
+      rpcUrls: ['https://polygon-rpc.com'],
       blockExplorerUrls: ['https://polygonscan.com/'],
     },
     stableCoins: [


### PR DESCRIPTION
Polygon vault ids were updated but not updated in boost config to match.

and switch rpc back to polygon-rpc.com