### PR TITLE
Fix: Wallet auto-reconnect

### DIFF
--- a/src/features/data/apis/wallet/wallet-connection.ts
+++ b/src/features/data/apis/wallet/wallet-connection.ts
@@ -14,16 +14,25 @@ import { createEIP1193Provider, WalletInit } from '@web3-onboard/common';
 
 export class WalletConnectionApi implements IWalletConnectionApi {
   protected onboard: OnboardAPI | null;
+  protected onboardWalletInitializers: WalletInit[] | null;
 
   constructor(protected options: WalletConnectionOptions) {
     this.onboard = null;
+    this.onboardWalletInitializers = null;
+  }
+
+  private getOnboardWalletInitializers(): WalletInit[] {
+    if (this.onboardWalletInitializers === null) {
+      this.onboardWalletInitializers = WalletConnectionApi.createOnboardWalletInitializers();
+    }
+    return this.onboardWalletInitializers;
   }
 
   /**
    * Create list of wallet modules for Onboard
    * @private
    */
-  private static createOnboardWallets() {
+  private static createOnboardWalletInitializers() {
     const injectedWallets = createInjectedWallets({
       custom: [
         {
@@ -179,7 +188,7 @@ export class WalletConnectionApi implements IWalletConnectionApi {
    */
   private createOnboard() {
     const onboard = Onboard({
-      wallets: WalletConnectionApi.createOnboardWallets(),
+      wallets: this.getOnboardWalletInitializers(),
       appMetadata: {
         name: 'Beefy Finance',
         icon: require(`../../../../images/bifi-logos/header-logo-notext.svg`).default,
@@ -298,6 +307,10 @@ export class WalletConnectionApi implements IWalletConnectionApi {
 
     // Initialize onboard if needed
     const onboard = this.getOnboard();
+
+    // Init wallets now; rather than in onboard.connect()
+    const walletInits = this.getOnboardWalletInitializers();
+    onboard.state.actions.setWalletModules(walletInits);
 
     // Last selected wallet must be valid
     const lastSelectedWalletExists =


### PR DESCRIPTION
Latest Onboard update delays initialising the wallet modules until connect is called, however we are checking to make sure the last connected wallet module exists, before trying to auto reconnect by calling connect. Since the wallet modules are not loaded, that check always fails, and no auto reconnect attempt is made.

This PR forces initialisation of the wallet moduels before the check/connect call.