### PR TITLE
Optimize rpc usage

### DIFF
--- a/src/features/data/apis/balance/balance.ts
+++ b/src/features/data/apis/balance/balance.ts
@@ -85,8 +85,6 @@ export class BalanceAPI<T extends ChainEntity> implements IBalanceApi {
 
     const results = await Promise.all([
       ...boostAndGovVaultPromises,
-      // ...boostPromises,
-      // ...govVaultPromises,
       ...erc20TokensPromises,
       ...nativeTokenPromises,
     ]);

--- a/src/features/data/apis/wallet/wallet-connection.ts
+++ b/src/features/data/apis/wallet/wallet-connection.ts
@@ -16,6 +16,8 @@ export class WalletConnectionApi implements IWalletConnectionApi {
   protected onboard: OnboardAPI | null;
   protected onboardWalletInitializers: WalletInit[] | null;
 
+  protected ignoreSetWalletModulesDisconnectEvent = false;
+
   constructor(protected options: WalletConnectionOptions) {
     this.onboard = null;
     this.onboardWalletInitializers = null;
@@ -231,6 +233,10 @@ export class WalletConnectionApi implements IWalletConnectionApi {
     const wallets = onboard.state.select('wallets');
     return wallets.subscribe(wallets => {
       if (wallets.length === 0) {
+        if (this.ignoreSetWalletModulesDisconnectEvent) {
+          console.log('Ignoring SetWalletModules disconnect event');
+          return (this.ignoreSetWalletModulesDisconnectEvent = false);
+        }
         this.options.onWalletDisconnected();
       } else {
         const wallet = wallets[0];
@@ -307,9 +313,11 @@ export class WalletConnectionApi implements IWalletConnectionApi {
 
     // Initialize onboard if needed
     const onboard = this.getOnboard();
+    console.log('where chimp said');
 
     // Init wallets now; rather than in onboard.connect()
     const walletInits = this.getOnboardWalletInitializers();
+    this.ignoreSetWalletModulesDisconnectEvent = true;
     onboard.state.actions.setWalletModules(walletInits);
 
     // Last selected wallet must be valid

--- a/src/features/data/apis/wallet/wallet-connection.ts
+++ b/src/features/data/apis/wallet/wallet-connection.ts
@@ -313,7 +313,6 @@ export class WalletConnectionApi implements IWalletConnectionApi {
 
     // Initialize onboard if needed
     const onboard = this.getOnboard();
-    console.log('where chimp said');
 
     // Init wallets now; rather than in onboard.connect()
     const walletInits = this.getOnboardWalletInitializers();

--- a/src/features/data/middlewares/wallet.ts
+++ b/src/features/data/middlewares/wallet.ts
@@ -27,6 +27,9 @@ export function walletActionsMiddleware(store: BeefyStore) {
     await next(action);
     const walletAddressAfter = store.getState().user.wallet.address;
 
+    // On rehydrate, avoid refetching since it will be triggered from scenario already
+    if (action.type === 'persist/REHYDRATE') return;
+
     if (walletAddressBefore !== walletAddressAfter && walletAddressAfter !== null) {
       // reload data if account has changed and we don't already have some data
       // ie: when user selects a totally new account, we want to fetch

--- a/src/features/data/utils/feature-flags.ts
+++ b/src/features/data/utils/feature-flags.ts
@@ -48,7 +48,7 @@ export function featureFlag_getBalanceApiChunkSize(): number {
   if (params.has('__balance_api_chunk_size')) {
     return parseInt(params.get('__balance_api_chunk_size'));
   }
-  return 500;
+  return 1024;
 }
 
 export function featureFlag_getAllowanceApiImplem(): 'eth-multicall' | 'new-multicall' {


### PR DESCRIPTION
- Double Balance multicall chunk size 500 => 1024
- Ignore setWalletModules disconnect event so as to keep showing balances from cached wallet address (example: if MM locks)
- Ignore hydrate action from wallet middleware, this avoids fetching all user balance data twice when loading the app with a stored wallet value
- Group up Boost and GovVault user balance RPC calls (same method signature)