### PR TITLE
Increase wallet init delay

### DIFF
--- a/src/features/data/actions/wallet.ts
+++ b/src/features/data/actions/wallet.ts
@@ -55,7 +55,7 @@ export const initWallet = createAsyncThunk<void, void, { state: BeefyState }>(
     // So we wait a small amount of time
     setTimeout(async () => {
       dispatch(tryToAutoReconnect());
-    }, 500);
+    }, 1000);
   }
 );
 


### PR DESCRIPTION
Injected wallets sometimes aren't available on Android in Metamask or Trust wallet browsers.