### PR TITLE
Add Velo USD+-LUSD vault, some OCD changes (score)

### DIFF
--- a/src/config/vault/bsc.json
+++ b/src/config/vault/bsc.json
@@ -17072,8 +17072,7 @@
       "MCAP_MICRO",
       "OVER_COLLAT_ALGO_STABLECOIN",
       "AUDIT",
-      "CONTRACTS_VERIFIED",
-      "OVER_COLLAT_ALGO_STABLECOIN"
+      "CONTRACTS_VERIFIED"
     ],
     "addLiquidityUrl": "https://ellipsis.finance/pool/0x68354c6E8Bbd020F9dE81EAf57ea5424ba9ef322",
     "buyTokenUrl": "https://ellipsis.finance/pool/0x68354c6E8Bbd020F9dE81EAf57ea5424ba9ef322",
@@ -17223,7 +17222,8 @@
       "MCAP_MICRO",
       "PLATFORM_ESTABLISHED",
       "AUDIT",
-      "CONTRACTS_VERIFIED"
+      "CONTRACTS_VERIFIED",
+      "OVER_COLLAT_ALGO_STABLECOIN"
     ],
     "addLiquidityUrl": "https://ellipsis.finance/pool/0xBcA6E25937B0F7E0FD8130076b6B218F595E32e2",
     "buyTokenUrl": "https://v1-app.jarvis.exchange/",

--- a/src/config/vault/fantom.json
+++ b/src/config/vault/fantom.json
@@ -181,8 +181,8 @@
   },
   {
     "id": "spiritV2-usdc-busd",
-    "name": "USDC-BUSD sLP",
-    "token": "USDC-BUSD sLP",
+    "name": "BUSD-USDC sLP",
+    "token": "BUSD-USDC sLP",
     "tokenAddress": "0xAfEcf681a8f3FB8D78581874339Bfca6252d62C4",
     "tokenDecimals": 18,
     "tokenProviderId": "spiritswap",
@@ -193,7 +193,7 @@
     "oracleId": "spiritV2-usdc-busd",
     "status": "active",
     "platformId": "spiritswap",
-    "assets": ["USDC", "BUSD"],
+    "assets": ["BUSD", "USDC"],
     "strategyTypeId": "lp",
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_NONE", "MCAP_LARGE", "CONTRACTS_VERIFIED"],
     "addLiquidityUrl": "https://beta.spiritswap.finance/liquidity",
@@ -447,7 +447,7 @@
       "COMPLEXITY_LOW",
       "BATTLE_TESTED",
       "IL_NONE",
-      "MCAP_HIGH",
+      "MCAP_LARGE",
       "CONTRACTS_VERIFIED",
       "OVER_COLLAT_ALGO_STABLECOIN"
     ],
@@ -889,7 +889,7 @@
       "COMPLEXITY_LOW",
       "NEW_STRAT",
       "IL_NONE",
-      "MCAP_SMALL",
+      "MCAP_MICRO",
       "AUDIT",
       "CONTRACTS_VERIFIED",
       "OVER_COLLAT_ALGO_STABLECOIN"

--- a/src/config/vault/metis.json
+++ b/src/config/vault/metis.json
@@ -486,7 +486,7 @@
     "risks": [
       "COMPLEXITY_LOW",
       "BATTLE_TESTED",
-      "IL_HIGH",
+      "IL_NONE",
       "MCAP_LARGE",
       "AUDIT",
       "CONTRACTS_VERIFIED"

--- a/src/config/vault/moonriver.json
+++ b/src/config/vault/moonriver.json
@@ -573,8 +573,8 @@
     "risks": [
       "COMPLEXITY_LOW",
       "BATTLE_TESTED",
-      "IL_LOW",
-      "MCAP_MEDIUM",
+      "IL_NONE",
+      "MCAP_LARGE",
       "AUDIT",
       "CONTRACTS_VERIFIED"
     ],

--- a/src/config/vault/optimism.json
+++ b/src/config/vault/optimism.json
@@ -27,6 +27,35 @@
     "createdAt": 1663091478
   },
   {
+    "id": "velodrome-usd+-lusd",
+    "name": "USD+-LUSD sLP",
+    "token": "USD+-LUSD sLP",
+    "tokenAddress": "0x8a9Cd3dce710e90177B4332C108E159a15736A0F",
+    "tokenDecimals": 18,
+    "tokenProviderId": "velodrome",
+    "earnedToken": "mooVeloUSD+-LUSD",
+    "earnedTokenAddress": "0x3b6eD6A53a9a357a397fbc7A04C96BA8B4AEBed2",
+    "earnContractAddress": "0x3b6eD6A53a9a357a397fbc7A04C96BA8B4AEBed2",
+    "oracle": "lps",
+    "oracleId": "velodrome-usd+-lusd",
+    "status": "active",
+    "platformId": "velodrome",
+    "assets": ["USD+", "LUSD"],
+    "strategyTypeId": "lp",
+    "risks": [
+      "COMPLEXITY_LOW",
+      "BATTLE_TESTED",
+      "IL_NONE",
+      "MCAP_MICRO",
+      "CONTRACTS_VERIFIED",
+      "OVER_COLLAT_ALGO_STABLECOIN"
+    ],
+    "addLiquidityUrl": "https://app.velodrome.finance/liquidity/create",
+    "buyTokenUrl": "https://app.velodrome.finance/swap",
+    "network": "optimism",
+    "createdAt": 1664540189
+  },
+  {
     "id": "velodrome-jeur-ageur",
     "name": "jEUR-agEUR sLP",
     "token": "jEUR-agEUR sLP",
@@ -42,7 +71,14 @@
     "platformId": "velodrome",
     "assets": ["jEUR", "agEUR"],
     "strategyTypeId": "lp",
-    "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_NONE", "MCAP_SMALL", "CONTRACTS_VERIFIED"],
+    "risks": [
+      "COMPLEXITY_LOW",
+      "BATTLE_TESTED",
+      "IL_NONE",
+      "MCAP_MICRO",
+      "CONTRACTS_VERIFIED",
+      "OVER_COLLAT_ALGO_STABLECOIN"
+    ],
     "addLiquidityUrl": "https://app.velodrome.finance/liquidity/create",
     "buyTokenUrl": "https://app.velodrome.finance/swap",
     "network": "optimism",
@@ -89,10 +125,10 @@
     "risks": [
       "COMPLEXITY_LOW",
       "BATTLE_TESTED",
-      "IL_LOW",
-      "MCAP_LARGE",
+      "IL_HIGH",
+      "MCAP_MEDIUM",
       "CONTRACTS_VERIFIED",
-      "OVER_COLLAT_ALGO_STABLECOIN"
+      "ALGO_STABLE"
     ],
     "addLiquidityUrl": "https://app.velodrome.finance/liquidity/create",
     "buyTokenUrl": "https://app.velodrome.finance/swap",
@@ -143,7 +179,7 @@
       "IL_NONE",
       "MCAP_MICRO",
       "CONTRACTS_VERIFIED",
-      "OVERCOLLAT_ALGO_STABLE"
+      "OVER_COLLAT_ALGO_STABLECOIN"
     ],
     "addLiquidityUrl": "https://app.velodrome.finance/liquidity/create",
     "buyTokenUrl": "https://app.velodrome.finance/swap",
@@ -166,7 +202,14 @@
     "platformId": "velodrome",
     "assets": ["agEUR", "MAI"],
     "strategyTypeId": "lp",
-    "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_NONE", "MCAP_SMALL", "CONTRACTS_VERIFIED"],
+    "risks": [
+      "COMPLEXITY_LOW",
+      "BATTLE_TESTED",
+      "IL_LOW",
+      "MCAP_MICRO",
+      "OVER_COLLAT_ALGO_STABLECOIN",
+      "CONTRACTS_VERIFIED"
+    ],
     "addLiquidityUrl": "https://app.velodrome.finance/liquidity/create",
     "buyTokenUrl": "https://app.velodrome.finance/swap",
     "network": "optimism",

--- a/src/config/vault/polygon.json
+++ b/src/config/vault/polygon.json
@@ -40,15 +40,15 @@
     "oracleId": "dystopia-usd+-usdc",
     "status": "active",
     "platformId": "dystopia",
-    "assets": ["USD+","USDC"],
+    "assets": ["USD+", "USDC"],
     "strategyTypeId": "lp",
-    "risks":[
+    "risks": [
       "COMPLEXITY_LOW",
       "BATTLE_TESTED",
       "IL_NONE",
       "MCAP_MICRO",
       "CONTRACTS_VERIFIED",
-      "OVERCOLLAT_ALGO_STABLE"
+      "OVER_COLLAT_ALGO_STABLECOIN"
     ],
     "addLiquidityUrl": "https://www.dystopia.exchange/liquidity",
     "buyTokenUrl": "https://www.dystopia.exchange/swap",
@@ -99,7 +99,7 @@
       "IL_HIGH",
       "MCAP_MICRO",
       "CONTRACTS_VERIFIED",
-      "OVERCOLLAT_ALGO_STABLE"
+      "OVER_COLLAT_ALGO_STABLECOIN"
     ],
     "addLiquidityUrl": "https://www.dystopia.exchange/liquidity",
     "buyTokenUrl": "https://www.dystopia.exchange/swap",
@@ -128,7 +128,7 @@
       "IL_HIGH",
       "MCAP_MICRO",
       "CONTRACTS_VERIFIED",
-      "OVERCOLLAT_ALGO_STABLE"
+      "OVER_COLLAT_ALGO_STABLECOIN"
     ],
     "addLiquidityUrl": "https://www.dystopia.exchange/liquidity",
     "buyTokenUrl": "https://www.dystopia.exchange/swap",
@@ -374,7 +374,7 @@
       "IL_NONE",
       "MCAP_MICRO",
       "CONTRACTS_VERIFIED",
-      "OVER_COLLAT_ALGO_STABLECOIN"
+      "ALGO_STABLE"
     ],
     "addLiquidityUrl": "https://www.dystopia.exchange/liquidity",
     "buyTokenUrl": "https://www.dystopia.exchange/swap",
@@ -8150,7 +8150,8 @@
       "MCAP_MICRO",
       "PLATFORM_ESTABLISHED",
       "AUDIT",
-      "CONTRACTS_VERIFIED"
+      "CONTRACTS_VERIFIED",
+      "OVER_COLLAT_ALGO_STABLECOIN"
     ],
     "addLiquidityUrl": "https://polygon.curve.fi/factory/304/deposit",
     "createdAt": 1663633678,


### PR DESCRIPTION
API PR: https://github.com/beefyfinance/beefy-api/pull/941

Moo Velo USD+-LUSD
Vault: 0x3b6eD6A53a9a357a397fbc7A04C96BA8B4AEBed2
Strategy: 0x6E2DCebF8C14c72329f224A26EdfD547d3c3E09c
Want: 0x8a9Cd3dce710e90177B4332C108E159a15736A0F
gauge: 0x1032950B49fc23316655E5d0Cc066BCd85B28EC7