### PR TITLE
Patch: Wallet errors not showing

### DIFF
--- a/src/features/data/actions/wallet-actions.tsx
+++ b/src/features/data/actions/wallet-actions.tsx
@@ -916,6 +916,7 @@ function captureWalletErrors<ReturnType>(
           token: null,
         })
       );
+      dispatch(stepperActions.setStepContent({ stepContent: StepContent.ErrorTx }));
     }
   };
 }
@@ -974,6 +975,7 @@ function bindTransactionEvents<T extends { amount: BigNumber; token: TokenEntity
     })
     .catch(error => {
       dispatch(createWalletActionErrorAction({ message: String(error) }, additionalData));
+      dispatch(stepperActions.setStepContent({ stepContent: StepContent.ErrorTx }));
     });
 }
 


### PR DESCRIPTION
Stepper bar would turn red showing there was an error; but the content did not update to show the content of that error.

Future: This needs rewritten so that it happens automatically on dispatching an error (vs having to also dispatch a seperate action to set the stepper content to the error state as happens now).