### PR TITLE
Reactivate sFTMx-FTM with upgraded strategy

### DIFF
--- a/src/config/vault/fantom.json
+++ b/src/config/vault/fantom.json
@@ -7300,8 +7300,7 @@
     "earnContractAddress": "0x30E3154ce70660590FC8bBc1929Ce9236e66C50E",
     "oracle": "lps",
     "oracleId": "boo-wftm-sftmx",
-    "status": "paused",
-    "pauseReason": "upgrade",
+    "status": "active",
     "platformId": "spookyswap",
     "assets": ["sFTMx", "FTM"],
     "strategyTypeId": "lp",
@@ -7315,7 +7314,7 @@
     ],
     "addLiquidityUrl": "https://spooky.fi/#/add/0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83/0xd7028092c830b5C8FcE061Af2E593413EbbC1fc1",
     "buyTokenUrl": "https://spooky.fi/#/swap?outputCurrency=0xd7028092c830b5C8FcE061Af2E593413EbbC1fc1",
-    "createdAt": 1650967301,
+    "createdAt": 1671306348,
     "network": "fantom"
   },
   {


### PR DESCRIPTION
This vault has a pending upgrade to a new strategy :warning: 

Vault to upgrade: 0x30E3154ce70660590FC8bBc1929Ce9236e66C50E
New strategy: 0x522f2f8fDAf0d24aEC705faDd09be5412b188545