### PR TITLE
update equalizer add liquidity links to one currently working

### DIFF
--- a/src/config/vault/fantom.json
+++ b/src/config/vault/fantom.json
@@ -130,7 +130,7 @@
     "assets": ["USDC", "ETH"],
     "strategyTypeId": "lp",
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_HIGH", "CONTRACTS_VERIFIED"],
-    "addLiquidityUrl": "https://equalizer.exchange/liquidity/0x515d84c494454835443B303a914a341e80f67278",
+    "addLiquidityUrl": "https://equalizer.exchange/liquidity/",
     "buyTokenUrl": "https://equalizer.exchange/swap",
     "network": "fantom",
     "createdAt": 1670954581
@@ -152,7 +152,7 @@
     "assets": ["USDC", "DAI"],
     "strategyTypeId": "lp",
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_NONE", "MCAP_HIGH", "CONTRACTS_VERIFIED"],
-    "addLiquidityUrl": "https://equalizer.exchange/liquidity/0x0f03efdce7A8cE08c238b1a0B5425Fb63Bd44b38",
+    "addLiquidityUrl": "https://equalizer.exchange/liquidity/",
     "buyTokenUrl": "https://equalizer.exchange/swap",
     "network": "fantom",
     "createdAt": 1672282535
@@ -174,7 +174,7 @@
     "assets": ["DAI", "FTM"],
     "strategyTypeId": "lp",
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_HIGH", "CONTRACTS_VERIFIED"],
-    "addLiquidityUrl": "https://equalizer.exchange/liquidity/0x0f03efdce7A8cE08c238b1a0B5425Fb63Bd44b38",
+    "addLiquidityUrl": "https://equalizer.exchange/liquidity/",
     "buyTokenUrl": "https://equalizer.exchange/swap",
     "network": "fantom",
     "createdAt": 1670954581
@@ -196,7 +196,7 @@
     "assets": ["BIFI", "FTM"],
     "strategyTypeId": "lp",
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
-    "addLiquidityUrl": "https://equalizer.exchange/liquidity/0x0b4b1e0325a7150468f724BCa3de2Deb92519846",
+    "addLiquidityUrl": "https://equalizer.exchange/liquidity/",
     "buyTokenUrl": "https://equalizer.exchange/swap",
     "network": "fantom",
     "createdAt": 1672879653
@@ -218,7 +218,7 @@
     "assets": ["ETH", "FTM"],
     "strategyTypeId": "lp",
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_HIGH", "CONTRACTS_VERIFIED"],
-    "addLiquidityUrl": "https://equalizer.exchange/liquidity/0xE3bD349BDb8203C15426b2d273f57568E658F843",
+    "addLiquidityUrl": "https://equalizer.exchange/liquidity/",
     "buyTokenUrl": "https://equalizer.exchange/swap",
     "network": "fantom",
     "createdAt": 1670954581
@@ -240,7 +240,7 @@
     "assets": ["USDC", "FTM"],
     "strategyTypeId": "lp",
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_HIGH", "CONTRACTS_VERIFIED"],
-    "addLiquidityUrl": "https://equalizer.exchange/liquidity/0x7547d05dFf1DA6B4A2eBB3f0833aFE3C62ABD9a1",
+    "addLiquidityUrl": "https://equalizer.exchange/liquidity/",
     "buyTokenUrl": "https://equalizer.exchange/swap",
     "network": "fantom",
     "createdAt": 1670954581


### PR DESCRIPTION
can be reverted if equalizer fixes their links for the specific LPs