### PR TITLE
Boost sorting

### DIFF
--- a/src/features/data/selectors/boosts.ts
+++ b/src/features/data/selectors/boosts.ts
@@ -138,6 +138,14 @@ export const selectShouldDisplayVaultBoost = (state: BeefyState, vaultId: VaultE
   return false;
 };
 
+export const selectVaultsActiveBoostPeriodFinish = (
+  state: BeefyState,
+  vaultId: BoostEntity['id']
+) => {
+  const activeBoost = selectVaultCurrentBoostIdWithStatus(state, vaultId);
+  return activeBoost ? selectBoostPeriodFinish(state, activeBoost.id) : null;
+};
+
 export const selectBoostPeriodFinish = (state: BeefyState, boostId: BoostEntity['id']) => {
   return state.entities.boosts.contractState[boostId]?.periodFinish || null;
 };

--- a/src/features/data/selectors/filtered-vaults.ts
+++ b/src/features/data/selectors/filtered-vaults.ts
@@ -16,8 +16,10 @@ import {
 } from './balance';
 import {
   selectBoostById,
+  selectIsVaultPrestakedBoost,
   selectIsVaultPreStakedOrBoosted,
   selectPreStakeOrActiveBoostIds,
+  selectVaultsActiveBoostPeriodFinish,
 } from './boosts';
 import {
   selectIsVaultBeefy,
@@ -295,7 +297,13 @@ export const selectFilteredVaults = (state: BeefyState) => {
       );
     } else {
       // Surface boosted
-      sortedVaults = sortBy(sortedVaults, vault => (vaultIsBoosted[vault.id] ? -1 : 1));
+      sortedVaults = sortBy(sortedVaults, vault =>
+        vaultIsBoosted[vault.id]
+          ? selectIsVaultPrestakedBoost(state, vault.id)
+            ? -Number.MAX_SAFE_INTEGER
+            : -selectVaultsActiveBoostPeriodFinish(state, vault.id)
+          : 1
+      );
     }
   }
 


### PR DESCRIPTION
Show prestake boosts first, sort active boosts by periodFinish and vaults after that