### PR TITLE
Specify the required node version 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "commonjs",
+  "engines": {
+    "node": "16.x"
+  },
   "dependencies": {
     "@babel/runtime": "^7.17.2",
     "@coinbase/wallet-sdk": "^3.0.10",


### PR DESCRIPTION
Running the project on Node 18 currently raises the following:
```
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (~/workspace/beefy-v2/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (~/workspace/beefy-v2/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (~/workspace/beefy-v2/node_modules/webpack/lib/NormalModule.js:471:10)
    at ~/workspace/beefy-v2/node_modules/webpack/lib/NormalModule.js:503:5
    at ~/workspace/beefy-v2/node_modules/webpack/lib/NormalModule.js:358:12
    at ~/workspace/beefy-v2/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (~/workspace/beefy-v2/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at iterateNormalLoaders (~/workspace/beefy-v2/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
~/workspace/beefy-v2/node_modules/react-scripts/scripts/start.js:19
  throw err;
  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (~/workspace/beefy-v2/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (~/workspace/beefy-v2/node_modules/webpack/lib/NormalModule.js:417:16)
    at ~/workspace/beefy-v2/node_modules/webpack/lib/NormalModule.js:452:10
    at ~/workspace/beefy-v2/node_modules/webpack/lib/NormalModule.js:323:13
    at ~/workspace/beefy-v2/node_modules/loader-runner/lib/LoaderRunner.js:367:11
    at ~/workspace/beefy-v2/node_modules/loader-runner/lib/LoaderRunner.js:233:18
    at context.callback (~/workspace/beefy-v2/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at ~/workspace/beefy-v2/node_modules/react-scripts/node_modules/babel-loader/lib/index.js:59:103 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v18.12.0
```