### PR TITLE
Fix: canto-note-usdc oracleId

### DIFF
--- a/src/config/vault/canto.json
+++ b/src/config/vault/canto.json
@@ -182,7 +182,7 @@
     "earnedTokenAddress": "0x36cB35a61437ab76970982Ace2EE77b9442f2F26",
     "earnContractAddress": "0x36cB35a61437ab76970982Ace2EE77b9442f2F26",
     "oracle": "lps",
-    "oracleId": "canto-note-usdt",
+    "oracleId": "canto-note-usdc",
     "status": "active",
     "platformId": "cantoDex",
     "assets": ["NOTE", "USDC"],


### PR DESCRIPTION
Was `canto-note-usdt` instead of `canto-note-usdc`