### PR TITLE
feat: add link to vault for dashboard

### DIFF
--- a/src/features/dashboard/components/ChainTable/components/TableVaults/Vault.tsx
+++ b/src/features/dashboard/components/ChainTable/components/TableVaults/Vault.tsx
@@ -1,5 +1,6 @@
 import { makeStyles, useMediaQuery } from '@material-ui/core';
 import React, { memo } from 'react';
+import { Link } from 'react-router-dom';
 import { AssetsImage } from '../../../../../../components/AssetsImage';
 import { Tooltip } from '../../../../../../components/Tooltip';
 import { BasicTooltipContent } from '../../../../../../components/Tooltip/BasicTooltipContent';
@@ -20,15 +21,20 @@ interface VaultProps {
 
 export const Vault = memo<VaultProps>(function ({ vaultId }) {
   const classes = useStyles();
-
   return (
-    <div className={classes.vault}>
+    <Link
+      to={`/vault/${vaultId}`}
+      style={{
+        textDecoration: 'none',
+      }}
+      className={classes.vault}
+    >
       <VaultName vaultId={vaultId} />
       <VaultPlatformStat className={classes.itemSmall} showLabel={false} vaultId={vaultId} />
       <VaultDepositStat className={classes.itemBig} showLabel={false} vaultId={vaultId} />
       <VaultYearlyStat className={classes.itemSmall} showLabel={false} vaultId={vaultId} />
       <VaultDailyUsdStat className={classes.itemBig} showLabel={false} vaultId={vaultId} />
-    </div>
+    </Link>
   );
 });
 


### PR DESCRIPTION
Hi, I use `/dashboard` a lot to check my vaults but there's no links for those vaults. Which means I had to visit the home page and select `My Vaults` there which is sort of inconvenient.

![](https://user-images.githubusercontent.com/126733611/224624196-4db01e03-cabc-4d19-9a6f-b4b30cac0ad0.png)

This pull request adds link to those vaults under dashboard which would be useful for users like me, let me know what you think.