### PR TITLE
[FIX] don't add assets to lists with < $10

### DIFF
--- a/src/features/treasury/components/DaoHoldings/DaoHoldings.tsx
+++ b/src/features/treasury/components/DaoHoldings/DaoHoldings.tsx
@@ -72,21 +72,4 @@ export const DaoHoldings = memo(function () {
       </div>
     </Section>
   );
-
-  // const breakpoints = { default: 3, 1296: 2, 960: 1 };
-  //
-  //
-  // return (
-  //   <Section title={t('Treasury-Title-Holdings')}>
-  //     <Masonry
-  //       className={classes.container}
-  //       columnClassName={classes.columnClassName}
-  //       breakpointCols={breakpoints}
-  //     >
-  //       {Object.values(sortedTreasury).map(chain => (
-  //         <ChainHolding key={chain.chainId} chainId={chain.chainId} />
-  //       ))}
-  //     </Masonry>
-  //   </Section>
-  // );
 });

--- a/src/features/treasury/components/DaoHoldings/components/AssetInfo/AssetInfo.tsx
+++ b/src/features/treasury/components/DaoHoldings/components/AssetInfo/AssetInfo.tsx
@@ -24,13 +24,6 @@ export const AssetInfo = memo<AssetInfoProps>(function ({ chainId, token }) {
 
   const isLP = token.assetType === 'token' && token.oracleType === 'lps';
 
-  const usdValue = token.usdValue;
-
-  //HIDE: All tokens with less than 10 usd
-  if (usdValue.lt(10)) {
-    return null;
-  }
-
   if (isVault) {
     return (
       <AssetContainer token={token}>

--- a/src/features/treasury/components/DaoHoldings/components/Assets/hooks.tsx
+++ b/src/features/treasury/components/DaoHoldings/components/Assets/hooks.tsx
@@ -20,14 +20,17 @@ export const useSortedAssets = (assets: TreasuryHoldingEntity[]): SortedAssetCat
   };
 
   for (const token of sortedAssets) {
-    if (token.assetType === 'token' || token.assetType === 'native') {
-      list.liquidAssets.push(token);
-    }
-    if (token.assetType === 'vault') {
-      list.stakedAssets.push(token);
-    }
-    if (token.assetType === 'validator') {
-      list.lockedAssets.push(token);
+    //HIDE: All tokens with less than 10 usd
+    if (token.usdValue.gt(10)) {
+      if (token.assetType === 'token' || token.assetType === 'native') {
+        list.liquidAssets.push(token);
+      }
+      if (token.assetType === 'vault') {
+        list.stakedAssets.push(token);
+      }
+      if (token.assetType === 'validator') {
+        list.lockedAssets.push(token);
+      }
     }
   }
 


### PR DESCRIPTION
With the old way, if any of the liquid/staked/locked assets had only one asset and it had less than $10, the title is shown without any item
![image](https://user-images.githubusercontent.com/88328748/225692679-91c57cdd-7dac-4943-9a03-be90cb93729c.png)
