### PR TITLE
[FIX] avoid set underlyingBalance/usdBalance as null to avoid broke app

### DIFF
--- a/src/helpers/timeserie.ts
+++ b/src/helpers/timeserie.ts
@@ -93,9 +93,9 @@ export function getInvestorTimeserie(
     const balance = timeline[balanceIdx].shareBalance;
     const shares = sortedShares[sharesIdx];
     const underlying = sortedUnderlying[underlyingIdx];
-    const underlyingBalance = shares && balance ? shares.value.times(balance) : null;
+    const underlyingBalance = shares && balance ? shares.value.times(balance) : BIG_ZERO;
     const usdBalance =
-      underlyingBalance && underlying ? underlyingBalance.times(underlying.value) : null;
+      underlyingBalance && underlying ? underlyingBalance.times(underlying.value) : BIG_ZERO;
 
     if (balance && !balance.isEqualTo(BIG_ZERO)) {
       pricesTs.push({


### PR DESCRIPTION
avoid setting as null since when try to do `.toNumber()` app will crash