### PR TITLE
[FIX] long names break vault page layout

### DIFF
--- a/src/features/vault/components/VaultHeader/index.tsx
+++ b/src/features/vault/components/VaultHeader/index.tsx
@@ -11,6 +11,8 @@ import { VaultPlatform } from '../../../../components/VaultPlatform';
 import { styles } from './styles';
 import { ShareButton } from '../ShareButton';
 
+const PUNCTUATION = new RegExp(/([/,-])/g);
+
 const useStyles = makeStyles(styles);
 
 export type VaultHeaderProps = {
@@ -27,7 +29,7 @@ export const VaultHeader = memo<VaultHeaderProps>(function ({ vaultId }) {
       <div className={classes.titleHolder}>
         <AssetsImage assetIds={vault.assetIds} size={48} chainId={vault.chainId} />
         <h1 className={classes.title}>
-          {vault.name} {!isGovVault(vault) ? t('Vault-vault') : ''}
+          {vault.name.replace(PUNCTUATION, '$1\u200B')} {!isGovVault(vault) ? t('Vault-vault') : ''}
         </h1>
       </div>
       <div className={classes.labelsHolder}>


### PR DESCRIPTION
Fix this 
<img width="278" alt="image" src="https://user-images.githubusercontent.com/88328748/226444218-8c518abe-2530-4e8a-a41d-50bb790adf8d.png">
