### PR TITLE
Enable 1inch zap fee

### DIFF
--- a/src/config/zap/one-inch.json
+++ b/src/config/zap/one-inch.json
@@ -4,8 +4,8 @@
     "priceOracleAddress": "0x7F069df72b7A39bCE9806e3AfaF579E54D8CF2b9",
     "chainId": "polygon",
     "fee": {
-      "original": 0.0005,
-      "value": 0
+      "value": 0.0005,
+      "recipient": "0x8Af5c669620B5e525CE85DB00D0c159FF6BbE983"
     },
     "depositFromTokens": ["MATIC", "WMATIC", "USDC", "USDT", "DAI", "MAI", "ETH", "WBTC"],
     "withdrawToTokens": ["MATIC", "BIFI", "USDC", "USDT", "DAI", "MAI", "ETH", "WBTC"],
@@ -53,8 +53,8 @@
     "priceOracleAddress": "0xE8E598A1041b6fDB13999D275a202847D9b654ca",
     "chainId": "fantom",
     "fee": {
-      "original": 0.0005,
-      "value": 0
+      "value": 0.0005,
+      "recipient": "0xCA2D9d7E28D4eeDA954074314d44a1a20c74DcbD"
     },
     "depositFromTokens": ["FTM", "WFTM", "USDC", "fUSDT", "DAI", "MIM", "MAI", "WETH", "WBTC"],
     "withdrawToTokens": ["FTM", "BIFI", "USDC", "fUSDT", "DAI", "MIM", "MAI", "WETH", "WBTC"],
@@ -149,8 +149,8 @@
     "priceOracleAddress": "0xBd0c7AaF0bF082712EbE919a9dD94b2d978f79A9",
     "chainId": "avax",
     "fee": {
-      "original": 0.0005,
-      "value": 0
+      "value": 0.0005,
+      "recipient": "0x515888C6585D076F3FeC413Cf44b457F507A8D3f"
     },
     "depositFromTokens": [
       "AVAX",
@@ -200,8 +200,8 @@
     "priceOracleAddress": "0x735247fb0a604c0adC6cab38ACE16D0DbA31295F",
     "chainId": "arbitrum",
     "fee": {
-      "original": 0.0005,
-      "value": 0
+      "value": 0.0005,
+      "recipient": "0x8Ccf8606ccf0Aff9937B68e0297967e257eB148b"
     },
     "depositFromTokens": ["ETH", "WETH", "USDC", "USDT", "DAI", "MIM", "WBTC"],
     "withdrawToTokens": ["ETH", "BIFI", "USDC", "USDT", "DAI", "MIM", "WBTC"],
@@ -224,8 +224,8 @@
     "priceOracleAddress": "0xfbD61B037C325b959c0F6A7e69D8f37770C2c550",
     "chainId": "bsc",
     "fee": {
-      "original": 0.0005,
-      "value": 0
+      "value": 0.0005,
+      "recipient": "0xc11986544b98697e45c9F05E0a98b3643D51aF2D"
     },
     "depositFromTokens": ["BNB", "WBNB", "BUSD", "USDC", "USDT", "DAI", "ETH", "BTCB"],
     "withdrawToTokens": ["BNB", "BIFI", "BUSD", "USDC", "USDT", "DAI", "ETH", "BTCB"],
@@ -284,8 +284,8 @@
     "priceOracleAddress": "0xE4E0552452e5cC1306A2bF5B2Fd9b1eA19418795",
     "chainId": "aurora",
     "fee": {
-      "original": 0.0005,
-      "value": 0
+      "value": 0.0005,
+      "recipient": "0xb267d9A7ED4B9A42a852a944E6f42E787a4a1c49"
     },
     "depositFromTokens": ["ETH", "WETH", "USDC", "USDT", "WBTC"],
     "withdrawToTokens": ["ETH", "BIFI", "USDC", "USDT", "WBTC"],
@@ -297,8 +297,8 @@
     "priceOracleAddress": "0x07D91f5fb9Bf7798734C3f606dB065549F6893bb",
     "chainId": "ethereum",
     "fee": {
-      "original": 0.0005,
-      "value": 0
+      "value": 0.0005,
+      "recipient": "0x0921E4fA2F85B6461fa83961d28DC7e1f9A32B40"
     },
     "depositFromTokens": ["ETH", "WETH", "USDC", "USDT", "DAI", "WBTC", "MIM"],
     "withdrawToTokens": ["ETH", "USDC", "USDT", "WBTC", "DAI", "MIM"],


### PR DESCRIPTION
safes
avax 0x515888C6585D076F3FeC413Cf44b457F507A8D3f
aurora 0xb267d9A7ED4B9A42a852a944E6f42E787a4a1c49
bnb 0xc11986544b98697e45c9F05E0a98b3643D51aF2D
ftm 0xCA2D9d7E28D4eeDA954074314d44a1a20c74DcbD

swapper contracts
arb 0x8Ccf8606ccf0Aff9937B68e0297967e257eB148b
eth 0x0921E4fA2F85B6461fa83961d28DC7e1f9A32B40
polygon 0x8Af5c669620B5e525CE85DB00D0c159FF6BbE983

