### PR TITLE
Hide EOL chains (HECO + Harmony) by default

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,14 +1,6 @@
-import React, { memo, PropsWithChildren } from 'react';
+import React, { memo } from 'react';
 import { makeStyles } from '@material-ui/core';
 import { styles } from './styles';
-import { useTranslation } from 'react-i18next';
-import { ReactComponent as IconGithub } from '../../images/socials/github.svg';
-import { ReactComponent as IconTelegram } from '../../images/socials/telegram.svg';
-import { ReactComponent as IconDiscord } from '../../images/socials/discord.svg';
-import { ReactComponent as IconTwitter } from '../../images/socials/twitter.svg';
-import { ReactComponent as IconReddit } from '../../images/socials/reddit.svg';
-import clsx from 'clsx';
-import { useLocation } from 'react-router';
 
 const useStyles = makeStyles(styles);
 

--- a/src/config/config.tsx
+++ b/src/config/config.tsx
@@ -639,6 +639,7 @@ export const config: Record<ChainConfig['id'], Omit<ChainConfig, 'id'>> = {
   },
   heco: {
     name: 'HECO',
+    eol: 1681913494,
     chainId: 128,
     rpc: ['https://http-mainnet.hecochain.com'],
     explorerUrl: 'https://hecoinfo.com',
@@ -666,6 +667,7 @@ export const config: Record<ChainConfig['id'], Omit<ChainConfig, 'id'>> = {
   },
   harmony: {
     name: 'Harmony',
+    eol: 1681913494,
     chainId: 1666600000,
     rpc: ['https://api.s0.t.hmny.io'],
     explorerUrl: 'https://explorer.harmony.one',

--- a/src/features/dashboard/components/UserVaults/hook.tsx
+++ b/src/features/dashboard/components/UserVaults/hook.tsx
@@ -2,7 +2,7 @@ import { sortBy } from 'lodash-es';
 import { useState, useCallback, useMemo } from 'react';
 import { useAppSelector } from '../../../../store';
 import { selectUserVaultsPnl } from '../../../data/selectors/balance';
-import { SelectUserFilteredVaults } from '../../../data/selectors/filtered-vaults';
+import { selectUserFilteredVaults } from '../../../data/selectors/filtered-vaults';
 
 export type SortedOptions = {
   sort: 'atDeposit' | 'now' | 'yield' | 'pnl' | 'apy' | 'dailyYield' | 'default';
@@ -23,7 +23,7 @@ export function useSortedDashboardVaults() {
     setSearchText('');
   }, []);
 
-  const filteredVaults = useAppSelector(state => SelectUserFilteredVaults(state, searchText));
+  const filteredVaults = useAppSelector(state => selectUserFilteredVaults(state, searchText));
 
   const apyByVaultId = useAppSelector(state => state.biz.apy.totalApy.byVaultId);
 

--- a/src/features/data/apis/config-types.ts
+++ b/src/features/data/apis/config-types.ts
@@ -123,6 +123,7 @@ export type GasConfig = StandardGasConfig | EIP1559GasConfig | CeloGasConfig;
 export interface ChainConfig {
   id: string;
   name: string;
+  eol?: number;
   chainId: number;
   rpc: string[];
   explorerUrl: string;

--- a/src/features/data/reducers/chains.ts
+++ b/src/features/data/reducers/chains.ts
@@ -6,10 +6,16 @@ import { NormalizedEntity } from '../utils/normalized-entity';
 /**
  * State containing Vault infos
  */
-export type ChainsState = NormalizedEntity<ChainEntity>;
+export type ChainsState = NormalizedEntity<ChainEntity> & {
+  activeIds: ChainEntity['id'][];
+  eolIds: ChainEntity['id'][];
+};
+
 export const initialChainsState: ChainsState = {
   byId: {},
   allIds: [],
+  activeIds: [],
+  eolIds: [],
 };
 
 export const chainsSlice = createSlice({
@@ -20,6 +26,8 @@ export const chainsSlice = createSlice({
   },
   extraReducers: builder => {
     builder.addCase(fetchChainConfigs.fulfilled, (sliceState, action) => {
+      const timestampNow = Date.now() / 1000;
+
       for (const chainConfig of action.payload.chainConfigs) {
         // we already know this chain
         if (chainConfig.id in sliceState.byId) {
@@ -35,6 +43,7 @@ export const chainsSlice = createSlice({
 
         sliceState.byId[chain.id] = chain;
         sliceState.allIds.push(chain.id);
+        sliceState[chain.eol && timestampNow > chain.eol ? 'eolIds' : 'activeIds'].push(chain.id);
       }
     });
   },

--- a/src/features/data/reducers/tvl.ts
+++ b/src/features/data/reducers/tvl.ts
@@ -13,6 +13,7 @@ import { BeefyState } from '../../../redux-types';
 import { reloadBalanceAndAllowanceAndGovRewardsAndBoostData } from '../actions/tokens';
 import { ChainEntity } from '../entities/chain';
 import { BIG_ZERO } from '../../../helpers/big-number';
+import { selectActiveChainIds } from '../selectors/chains';
 
 /**
  * State containing APY infos indexed by vault id
@@ -37,6 +38,7 @@ export interface TvlState {
     [chaindId: ChainEntity['id']]: BigNumber;
   };
 }
+
 export const initialTvlState: TvlState = {
   totalTvl: BIG_ZERO,
   byVaultId: {},
@@ -152,14 +154,20 @@ function addContractDataToState(
     sliceState.byBoostId[boost.id] = { tvl, staked: totalStaked };
   }
 
+  const activeChainIds = selectActiveChainIds(state);
   const byChaindIdTotals = {};
   let totalTvl = BIG_ZERO;
   for (const [vaultId, vaultTvl] of Object.entries(sliceState.byVaultId)) {
     const vault = selectVaultById(state, vaultId);
+
     byChaindIdTotals[vault.chainId] = byChaindIdTotals[vault.chainId]
       ? byChaindIdTotals[vault.chainId].plus(vaultTvl.tvl)
       : vaultTvl.tvl;
-    totalTvl = totalTvl.plus(vaultTvl.tvl);
+
+    // Only include active chains in total
+    if (activeChainIds.includes(vault.chainId)) {
+      totalTvl = totalTvl.plus(vaultTvl.tvl);
+    }
   }
   sliceState.byChaindId = byChaindIdTotals;
   // recompute total tvl as a whole

--- a/src/features/data/selectors/chains.ts
+++ b/src/features/data/selectors/chains.ts
@@ -4,20 +4,19 @@ import { BeefyState } from '../../../redux-types';
 import { ChainEntity } from '../entities/chain';
 import { selectChainNativeToken } from './tokens';
 
+function makeChainSelector(idsSelector: (state: BeefyState) => ChainEntity['id'][]) {
+  return createSelector(
+    idsSelector,
+    (state: BeefyState) => state.entities.chains.byId,
+    (allIds, byId) => allIds.map(id => byId[id])
+  );
+}
+
 export const selectChainById = createCachedSelector(
   (state, chainId) => chainId,
   state => state.entities.chains.byId,
   (chainId, byId): ChainEntity | undefined => byId[chainId]
 )((state, chainId) => chainId);
-
-export const selectAllChains = createSelector(
-  // get a tiny bit of the data
-  (state: BeefyState) => state.entities.chains.allIds,
-  // get a tiny bit of the data
-  (state: BeefyState) => state.entities.chains.byId,
-  // last function receives previous function outputs as parameters
-  (allIds, byId) => allIds.map(id => byId[id])
-);
 
 export const selectAllChainsNativeAssetsIsd = (state: BeefyState) => {
   const allChainIds = selectAllChainIds(state);
@@ -32,3 +31,9 @@ export const selectAllChainsNativeAssetsIsd = (state: BeefyState) => {
 };
 
 export const selectAllChainIds = (state: BeefyState) => state.entities.chains.allIds;
+export const selectActiveChainIds = (state: BeefyState) => state.entities.chains.activeIds;
+export const selectEolChainIds = (state: BeefyState) => state.entities.chains.eolIds;
+
+export const selectAllChains = makeChainSelector(selectAllChainIds);
+export const selectActiveChains = makeChainSelector(selectActiveChainIds);
+export const selectEolChains = makeChainSelector(selectEolChainIds);

--- a/src/features/home/components/Filters/components/ChainFilters/ChainButtonSelector.tsx
+++ b/src/features/home/components/Filters/components/ChainFilters/ChainButtonSelector.tsx
@@ -1,6 +1,6 @@
 import React, { FC, memo, SVGProps, useCallback } from 'react';
 import { ChainEntity } from '../../../../../data/entities/chain';
-import { selectAllChainIds, selectChainById } from '../../../../../data/selectors/chains';
+import { selectActiveChainIds, selectChainById } from '../../../../../data/selectors/chains';
 import { makeStyles, Tooltip } from '@material-ui/core';
 import { styles } from './styles';
 import clsx from 'clsx';
@@ -58,7 +58,7 @@ export const ChainButtonSelector = memo<ChainButtonSelectorProps>(function Chain
   className,
 }) {
   const classes = useStyles();
-  const chainIds = useAppSelector(selectAllChainIds);
+  const chainIds = useAppSelector(selectActiveChainIds);
   const handleChange = useCallback(
     (isSelected, id) => {
       if (isSelected) {

--- a/src/features/home/components/Filters/components/ChainFilters/ChainDropdownFilter.tsx
+++ b/src/features/home/components/Filters/components/ChainFilters/ChainDropdownFilter.tsx
@@ -1,9 +1,8 @@
 import React, { memo, ReactNode, useCallback, useMemo } from 'react';
 import { useAppDispatch, useAppSelector } from '../../../../../../store';
-import { selectFilterChainIds } from '../../../../../data/selectors/filtered-vaults';
 import { ChainEntity } from '../../../../../data/entities/chain';
 import { filteredVaultsActions } from '../../../../../data/reducers/filtered-vaults';
-import { selectAllChains } from '../../../../../data/selectors/chains';
+import { selectActiveChains } from '../../../../../data/selectors/chains';
 import {
   DropdownItemLabelProps,
   LabeledMultiSelect,
@@ -14,6 +13,7 @@ import { makeStyles } from '@material-ui/core';
 import { styles } from './styles';
 import clsx from 'clsx';
 import { getNetworkSrc } from '../../../../../../helpers/networkSrc';
+import { useSelectedChainIds } from './hooks';
 
 const useStyles = makeStyles(styles);
 
@@ -76,22 +76,22 @@ export const ChainDropdownFilter = memo<ChainDropdownFilterProps>(function Chain
   className,
 }) {
   const dispatch = useAppDispatch();
-  const allChains = useAppSelector(selectAllChains);
-  const selectedChainIds = useAppSelector(selectFilterChainIds);
+  const activeChains = useAppSelector(selectActiveChains);
+  const selectedChainIds = useSelectedChainIds();
   const { t } = useTranslation();
 
   const handleChange = useCallback(
     (selected: ChainEntity['id'][]) => {
       dispatch(
-        filteredVaultsActions.setChainIds(selected.length === allChains.length ? [] : selected)
+        filteredVaultsActions.setChainIds(selected.length === activeChains.length ? [] : selected)
       );
     },
-    [dispatch, allChains]
+    [dispatch, activeChains]
   );
 
   const options = useMemo(() => {
-    return Object.fromEntries(allChains.map(chain => [chain.id, chain.name]));
-  }, [allChains]);
+    return Object.fromEntries(activeChains.map(chain => [chain.id, chain.name]));
+  }, [activeChains]);
 
   return (
     <LabeledMultiSelect

--- a/src/features/home/components/Filters/components/ChainFilters/hooks.tsx
+++ b/src/features/home/components/Filters/components/ChainFilters/hooks.tsx
@@ -1,0 +1,24 @@
+import { useAppDispatch, useAppSelector } from '../../../../../../store';
+import { selectActiveChainIds } from '../../../../../data/selectors/chains';
+import { selectFilterChainIds } from '../../../../../data/selectors/filtered-vaults';
+import { useEffect } from 'react';
+import { filteredVaultsActions } from '../../../../../data/reducers/filtered-vaults';
+import { ChainEntity } from '../../../../../data/entities/chain';
+
+export function useSelectedChainIds(): ChainEntity['id'][] {
+  const dispatch = useAppDispatch();
+  const activeChainIds = useAppSelector(selectActiveChainIds);
+  const selectedChainIds = useAppSelector(selectFilterChainIds);
+
+  useEffect(() => {
+    if (!selectedChainIds.every(id => activeChainIds.includes(id))) {
+      dispatch(
+        filteredVaultsActions.setChainIds(
+          selectedChainIds.filter(id => activeChainIds.includes(id))
+        )
+      );
+    }
+  }, [activeChainIds, selectedChainIds]);
+
+  return selectedChainIds;
+}

--- a/src/features/home/components/Portfolio/ModalTvl/ModalTvl.tsx
+++ b/src/features/home/components/Portfolio/ModalTvl/ModalTvl.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '../../../../vault/comp
 import CloseIcon from '@material-ui/icons/Close';
 import { styles } from './styles';
 import { useTranslation } from 'react-i18next';
-import { selectChainById } from '../../../../data/selectors/chains';
+import { selectActiveChainIds, selectChainById } from '../../../../data/selectors/chains';
 import { ChainEntity } from '../../../../data/entities/chain';
 import { selectTvlByChain } from '../../../../data/selectors/tvl';
 import BigNumber from 'bignumber.js';
@@ -30,14 +30,16 @@ const _ModalTvl = forwardRef<HTMLDivElement, ModalTvlProps>(function ({ close },
   const classes = useStyles();
   const { t } = useTranslation();
   const tvls = useAppSelector(selectTvlByChain);
+  const activeChainIds = useAppSelector(selectActiveChainIds);
 
   const sortedTvls = React.useMemo<ItemListType[]>(() => {
     const list = [];
     for (const [chainId, tvl] of Object.entries(tvls)) {
+      if (!activeChainIds.includes(chainId)) continue;
       list.push({ tvl: tvl.toNumber(), chainId });
     }
     return orderBy(list, 'tvl', 'desc');
-  }, [tvls]);
+  }, [tvls, activeChainIds]);
 
   return (
     <div className={classes.holder} ref={ref} tabIndex={-1}>


### PR DESCRIPTION
- Hides EOL chains from both button and dropdown chain selector
- Does not list vaults from EOL chains *unless* no chain filter is set AND:
  - My vaults is selected and user is deposited in one of the vaults
  - or, 'Retired only' vaults filter is selected
- All rpc calls are still made / infra is still required to exist