### PR TITLE
Fix: data dashboard crash when missing prices

### DIFF
--- a/src/features/dashboard/components/UserVaults/components/VaultTransactions/VaultTransactions.tsx
+++ b/src/features/dashboard/components/UserVaults/components/VaultTransactions/VaultTransactions.tsx
@@ -28,7 +28,7 @@ export const VaultTransactions = memo<VaultTransactionsProps>(function VaultTran
 
   const vault = useAppSelector(state => selectVaultById(state, vaultId));
 
-  const token = useAppSelector(state =>
+  const depositToken = useAppSelector(state =>
     selectTokenByAddress(state, vault.chainId, vault.depositTokenAddress)
   );
 
@@ -44,7 +44,13 @@ export const VaultTransactions = memo<VaultTransactionsProps>(function VaultTran
     <div className={classes.transactionsGrid}>
       <TransactionsFilter sortOptions={sortedOptions} handleSort={handleSort} />
       {sortedTimeline.map(tx => {
-        return <TxComponent key={tx.datetime.getTime()} tokenDecimals={token.decimals} data={tx} />;
+        return (
+          <TxComponent
+            key={tx.datetime.getTime()}
+            tokenDecimals={depositToken.decimals}
+            data={tx}
+          />
+        );
       })}
     </div>
   );

--- a/src/features/dashboard/components/UserVaults/components/VaultTransactions/components/Transaction/Transaction.tsx
+++ b/src/features/dashboard/components/UserVaults/components/VaultTransactions/components/Transaction/Transaction.tsx
@@ -70,7 +70,7 @@ export const Transaction = memo<TransactionProps>(function Transaction({ data, t
         </div>
         {/*Usd Balance */}
         <div className={classes.column}>
-          <div className={classes.stat}>{formatBigUsd(usdBalance ?? BIG_ZERO)}</div>
+          <div className={classes.stat}>{formatBigUsd(usdBalance)}</div>
         </div>
       </InfoGrid>
     </Row>
@@ -137,10 +137,7 @@ export const TransactionMobile = memo<TransactionProps>(function TransactionMobi
           label={t('Dashboard-Filter-MooTokens')}
           value={mooTokenBal}
         />
-        <MobileStat
-          label={t('Dashboard-Filter-UsdBalance')}
-          value={formatBigUsd(usdBalance ?? BIG_ZERO)}
-        />
+        <MobileStat label={t('Dashboard-Filter-UsdBalance')} value={formatBigUsd(usdBalance)} />
       </InfoGrid>
     </RowMobile>
   );

--- a/src/features/data/apis/amm/SolidlyPool.ts
+++ b/src/features/data/apis/amm/SolidlyPool.ts
@@ -115,7 +115,7 @@ export class SolidlyPool implements IPool {
 
     this.pairData = {
       totalSupply: new BigNumber(result.totalSupply),
-      decimals: parseInt(result.totalSupply, 10),
+      decimals: parseInt(result.decimals, 10),
       token0: result.metadata[MetadataKeys.token0],
       token1: result.metadata[MetadataKeys.token1],
       reserves0: new BigNumber(result.metadata[MetadataKeys.reserves0]),

--- a/src/features/data/apis/amm/UniswapV2Pool.ts
+++ b/src/features/data/apis/amm/UniswapV2Pool.ts
@@ -115,7 +115,7 @@ export class UniswapV2Pool implements IPool {
 
     this.pairData = {
       totalSupply: new BigNumber(result.totalSupply),
-      decimals: parseInt(result.totalSupply, 10),
+      decimals: parseInt(result.decimals, 10),
       token0: result.token0,
       token1: result.token1,
       reserves0: new BigNumber(result.reserves[0]),

--- a/src/features/data/entities/analytics.ts
+++ b/src/features/data/entities/analytics.ts
@@ -2,27 +2,24 @@ import type BigNumber from 'bignumber.js';
 import type { TimelineAnalyticsConfig } from '../apis/analytics/analytics-types';
 import type { ChangeTypeOfKeys, SnakeToCamelCase } from '../utils/types-utils';
 
-export type VaultTimelineAnalyticsWithBigNumber = ChangeTypeOfKeys<
-  {
-    [K in keyof TimelineAnalyticsConfig as SnakeToCamelCase<K>]: TimelineAnalyticsConfig[K];
-  },
-  | 'shareBalance'
-  | 'shareDiff'
-  | 'shareToUnderlyingPrice'
-  | 'underlyingBalance'
-  | 'underlyingDiff'
-  | 'underlyingToUsdPrice'
-  | 'usdBalance'
-  | 'usdDiff',
+type VTACSnake = {
+  [K in keyof TimelineAnalyticsConfig as SnakeToCamelCase<K>]: TimelineAnalyticsConfig[K];
+};
+
+type VTACBigNumber = ChangeTypeOfKeys<
+  VTACSnake,
+  'shareBalance' | 'shareDiff' | 'shareToUnderlyingPrice' | 'underlyingBalance' | 'underlyingDiff',
   BigNumber
 >;
 
-export type VaultTimelineAnalyticsWithDateTime = ChangeTypeOfKeys<
-  VaultTimelineAnalyticsWithBigNumber,
-  'datetime',
-  Date
+type VTACOptionalBigNumber = ChangeTypeOfKeys<
+  VTACBigNumber,
+  'underlyingToUsdPrice' | 'usdBalance' | 'usdDiff',
+  BigNumber | null
 >;
 
-export type VaultTimelineAnalyticsEntity = VaultTimelineAnalyticsWithDateTime & {
+type VTACWithDateTime = ChangeTypeOfKeys<VTACOptionalBigNumber, 'datetime', Date>;
+
+export type VaultTimelineAnalyticsEntity = VTACWithDateTime & {
   internal?: boolean;
 };

--- a/src/features/vault/components/PnLGraph/hooks.tsx
+++ b/src/features/vault/components/PnLGraph/hooks.tsx
@@ -49,11 +49,11 @@ export const usePnLChartData = (
   );
   const vaultLastDeposit = useAppSelector(state => selectLastVaultDepositStart(state, vaultId));
 
-  const { data: shares, status: sharesStatus } = useAppSelector(state =>
+  const { data: sharesToUnderlying, status: sharesStatus } = useAppSelector(state =>
     selectShareToUnderlyingTimebucketByVaultId(state, vaultId, timebucket)
   );
 
-  const { data: underlying, status: underlyingStatus } = useAppSelector(state =>
+  const { data: underlyingToUsd, status: underlyingStatus } = useAppSelector(state =>
     selectUnderlyingToUsdTimebucketByVaultId(state, vaultId, timebucket)
   );
 
@@ -88,14 +88,18 @@ export const usePnLChartData = (
 
   const chartData = useMemo(() => {
     if (sharesStatus === 'fulfilled' && underlyingStatus === 'fulfilled') {
-      const filteredShares = shares.filter(price => isAfter(price.date, vaultLastDeposit));
-      const filteredUnderlying = underlying.filter(price => isAfter(price.date, vaultLastDeposit));
+      const filteredSharesToUnderlying = sharesToUnderlying.filter(price =>
+        isAfter(price.date, vaultLastDeposit)
+      );
+      const filteredUnderlyingToUsd = underlyingToUsd.filter(price =>
+        isAfter(price.date, vaultLastDeposit)
+      );
 
       const data = getInvestorTimeserie(
         timebucket,
         vaultTimeline,
-        filteredShares,
-        filteredUnderlying,
+        filteredSharesToUnderlying,
+        filteredUnderlyingToUsd,
         vaultLastDeposit,
         currentPpfs,
         currentOraclePrice,
@@ -117,8 +121,8 @@ export const usePnLChartData = (
     // We need to make sure this object is not modified elsewhere
     return NO_CHART_DATA;
   }, [
-    shares,
-    underlying,
+    sharesToUnderlying,
+    underlyingToUsd,
     currentMooTokenBalance,
     currentOraclePrice,
     currentPpfs,

--- a/src/features/vault/components/PnLGraph/hooks.tsx
+++ b/src/features/vault/components/PnLGraph/hooks.tsx
@@ -98,7 +98,7 @@ export const usePnLChartData = (
         filteredUnderlying,
         vaultLastDeposit,
         currentPpfs,
-        currentOraclePrice.toNumber(),
+        currentOraclePrice,
         currentMooTokenBalance
       );
 


### PR DESCRIPTION
To replace #1371 and #1464

For vault page:
- We replace any underlying price with current oracle price if < 24 hours old in `getInvestorTimeserie`

For dashboard page:
- We replace any underlying price with current oracle price if < 24 hours old in `useSortedTimeline`, and use that to calculate usdBalance and usdDiff also

Also
- Fix VaultTimelineAnalyticsEntity types via @prevostc 
- Fix formatUsd types + add suport for BigNumber input
- Fix pool decimals (was unused)
- Renamed some vars to help me understand