### PR TITLE
Use token image for Add to Wallet button

### DIFF
--- a/src/features/vault/components/AddTokenToWallet/AddTokenToWallet.tsx
+++ b/src/features/vault/components/AddTokenToWallet/AddTokenToWallet.tsx
@@ -5,6 +5,7 @@ import { AssetsImage } from '../../../../components/AssetsImage';
 import { Button } from '../../../../components/Button';
 import { LinkButton } from '../../../../components/LinkButton';
 import { useAppSelector } from '../../../../store';
+import { getSingleAssetSrc } from '../../../../helpers/singleAssetSrc';
 import type { ChainEntity } from '../../../data/entities/chain';
 import type { TokenEntity } from '../../../data/entities/token';
 import { selectChainById } from '../../../data/selectors/chains';
@@ -39,6 +40,7 @@ export const AddTokenToWallet = memo<AddTokenToWalletProps>(function AddTokenToW
             address: token.address,
             symbol: token.symbol,
             decimals: token.decimals,
+            image: window.location.origin + getSingleAssetSrc(token.id, chainId),
           },
         },
       });


### PR DESCRIPTION
On boosted vaults the earned token has an `Add to Wallet +` button, this PR replaces the generic identicon with the token's image for the user's wallet.

<img src="https://github.com/beefyfinance/beefy-v2/assets/4100078/39cf1946-1fb4-49b7-b481-f2833defe382" alt="Before" width="280"> → <img src="https://github.com/beefyfinance/beefy-v2/assets/4100078/c16c03e4-2289-44ad-98e6-3cecbefe7d96" alt="After" width="280">

Note that the absolute image path is required for this to work rather than a relative one (this took a while to debug), hence the use of `window.location.origin`.