### PR TITLE
Add RDNT-BNB PCS Farm + RDNT Token for BSC

### DIFF
--- a/src/config/vault/bsc.json
+++ b/src/config/vault/bsc.json
@@ -1,5 +1,36 @@
 [
   {
+    "id": "cakev2-wbnb-rdnt",
+    "name": "RDNT-BNB LP",
+    "token": "RDNT-BNB LP2",
+    "tokenAddress": "0x346575fC7f07E6994D76199E41D13dC1575322E1",
+    "tokenDecimals": 18,
+    "tokenProviderId": "pancakeswap",
+    "tokenAmmId": "bsc-pancakeswap-v2",
+    "earnedToken": "mooCakeV2RDNT-BNB",
+    "earnedTokenAddress": "0xe755a30A001E2Ac012e45DE6c271C38495471250",
+    "earnContractAddress": "0xe755a30A001E2Ac012e45DE6c271C38495471250",
+    "oracle": "lps",
+    "oracleId": "cakev2-wbnb-rdnt",
+    "status": "active",
+    "platformId": "pancakeswap",
+    "assets": ["RDNT", "BNB"],
+    "risks": [
+      "COMPLEXITY_LOW",
+      "BATTLE_TESTED",
+      "IL_HIGH",
+      "MCAP_MEDIUM",
+      "AUDIT",
+      "CONTRACTS_VERIFIED"
+    ],
+    "strategyTypeId": "lp",
+    "buyTokenUrl": "https://pancakeswap.finance/swap?outputCurrency=0xf7DE7E8A6bd59ED41a4b5fe50278b3B7f31384dF",
+    "addLiquidityUrl": "https://pancakeswap.finance/add/0xf7DE7E8A6bd59ED41a4b5fe50278b3B7f31384dF/BNB",
+    "removeLiquidityUrl": "https://pancakeswap.finance/remove/0xf7DE7E8A6bd59ED41a4b5fe50278b3B7f31384dF/BNB",
+    "network": "bsc",
+    "createdAt": 1687443400
+  },
+  {
     "id": "thena-gamma-bnbx-usdt-wide",
     "name": "BNBx-USDT Wide LP",
     "token": "awBNBX-USDT",


### PR DESCRIPTION
Proposal to add an RDNT-BNB vault on PancakeSwap. 240k locked on PCS, 18M total liquidity in the pool (most of it locked on Radiant)

**RDNT-BNB LP**
Vault : 0xe755a30A001E2Ac012e45DE6c271C38495471250
Strategy : 0x61F3ba9B6D886C11aa7690cA32E99559eB493817