### PR TITLE
Basic RPC rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "i18next": "^20.3.2",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash-es": "^4.17.21",
+    "p-queue": "^6.6.2",
     "re-reselect": "^4.0.0",
     "react": "18.2.0",
     "react-animate-height": "^2.0.23",

--- a/src/features/data/apis/instances.ts
+++ b/src/features/data/apis/instances.ts
@@ -10,11 +10,12 @@ import type {
 import { BridgeApi } from './bridge/bridge';
 import type { IOnRampApi } from './on-ramp/on-ramp-types';
 import type { ITransactApi } from './transact/transact-types';
-import { createWeb3Instance } from '../../../helpers/web3';
+import { createWeb3Instance, rateLimitWeb3Instance } from '../../../helpers/web3';
 import { createGasPricer } from './gas-prices';
 import { AnalyticsApi } from './analytics/analytics';
 import type { IOneInchApi } from './one-inch/one-inch-types';
 import type { IBeefyDataApi } from './beefy/beefy-data-api-types';
+import PQueue from 'p-queue';
 
 // todo: maybe don't instanciate here, idk yet
 const beefyApi = new BeefyAPI();
@@ -44,10 +45,18 @@ export function getAnalyticsApi(): AnalyticsApi {
 
 export const getWeb3Instance = createFactoryWithCacheByChain(async chain => {
   // pick one RPC endpoint at random
-  // todo: not the smartest thing to do but good enough yet
   const rpc = sample(chain.rpc);
-  console.debug(`Instanciating Web3 for chain ${chain.id}`);
-  return createWeb3Instance(rpc);
+  const requestsPerSecond = 10; // may need to be configurable per rpc [ankr allows ~30 rps]
+  const queue = new PQueue({
+    concurrency: requestsPerSecond,
+    intervalCap: requestsPerSecond,
+    interval: 1000,
+    carryoverConcurrencyCount: true,
+    autoStart: true,
+  });
+
+  console.debug(`Instantiating rate-limited Web3 for chain ${chain.id} via ${rpc}`);
+  return rateLimitWeb3Instance(createWeb3Instance(rpc), queue);
 });
 
 export const getGasPricer = createFactoryWithCacheByChain(async chain => {


### PR DESCRIPTION
Set to 10 requests per second.

Ankr public RPCs should be able to support up to 30 requests per second - [Ankr Rate Limits](https://www.ankr.com/docs/rpc-service/service-plans/#rate-limits)

Only effects public RPCs the app uses, not the RPC that the connected wallet uses to send TXs.

## Why?

Dashboard PR will mean connected wallet requests and dashboard/0xaddress requests can fire at same time.

## How

Had to hack in hooks for provider methods to add queue to send, sendAsync and request