### PR TITLE
Vault : Add Stable DOLA-MAI velodrome v2

### DIFF
--- a/src/config/vault/optimism.json
+++ b/src/config/vault/optimism.json
@@ -307,7 +307,7 @@
     "oracleId": "velodrome-v2-usd+-dola",
     "status": "active",
     "platformId": "velodrome",
-    "assets": ["alETH", "ETH"],
+    "assets": ["USD+", "DOLA"],
     "risks": ["COMPLEXITY_LOW", "IL_NONE", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x73cb180bf0521828d8849bc8cf2b920918e23032&to=0x8ae125e8653821e851f12a49f7765db9a9ce7384",

--- a/src/config/vault/optimism.json
+++ b/src/config/vault/optimism.json
@@ -1,5 +1,35 @@
 [
   {
+    "id": "velodrome-v2-dola-mai",
+    "name": "DOLA-MAI sLP V2",
+    "token": "DOLA-MAI sLP V2",
+    "tokenAddress": "0xBE418771bC91F75C4d2BcE1d5E2b7286F50992da",
+    "tokenDecimals": 18,
+    "tokenProviderId": "velodrome",
+    "earnedToken": "mooVeloV2DOLA-MAI",
+    "earnedTokenAddress": "0x35775aA87b4CA1c04a6c579c90cE9add09247958",
+    "earnContractAddress": "0x35775aA87b4CA1c04a6c579c90cE9add09247958",
+    "oracle": "lps",
+    "oracleId": "velodrome-v2-dola-mai",
+    "status": "active",
+    "platformId": "velodrome",
+    "assets": ["DOLA", "MAI"],
+    "risks": [
+      "COMPLEXITY_LOW",
+      "BATTLE_TESTED",
+      "IL_NONE",
+      "MCAP_SMALL",
+      "OVER_COLLAT_ALGO_STABLECOIN",
+      "CONTRACTS_VERIFIED"
+    ],
+    "strategyTypeId": "lp",
+    "buyTokenUrl": "https://velodrome.finance/swap?from=0x8ae125e8653821e851f12a49f7765db9a9ce7384&to=0xdfa46478f9e5ea86d57387849598dbfb2e964b02",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x8ae125e8653821e851f12a49f7765db9a9ce7384&token1=0xdfa46478f9e5ea86d57387849598dbfb2e964b02&stable=true",
+    "removeLiquidityUrl": "https://app.velodrome.finance/withdraw?pair=0xBE418771bC91F75C4d2BcE1d5E2b7286F50992da",
+    "network": "optimism",
+    "createdAt": 1688058796
+  },
+  {
     "id": "velodrome-v2-op-velo",
     "name": "VELO-OP vLP V2",
     "token": "VELO-OP vLP V2",


### PR DESCRIPTION
sAMM DOLA-MAI V2
Vault `0x35775aA87b4CA1c04a6c579c90cE9add09247958` is deployed with tx: 0x61f749b05317357ea40fd9ad247bdc2b1f2fa92ba03bd0084e288efb1d71ab4b
Strat `0x03C0350e6FF5EDaC390a98896c3034FF627d5CCc` is deployed with tx: 0x447f0011b3482feb74e40b4b57a500012889742dc8b7716c0b058bfc3057d8aa

Fix `velodrome-v2-usd+-dola` assetIds array