### PR TITLE
Add explorer url templates + helper functions

### DIFF
--- a/src/components/Stepper/components/BridgeContent/BridgeInfo.tsx
+++ b/src/components/Stepper/components/BridgeContent/BridgeInfo.tsx
@@ -19,6 +19,7 @@ import { stepperActions } from '../../../../features/data/reducers/wallet/steppe
 import { walletActions } from '../../../../features/data/actions/wallet-actions';
 import { getNetworkSrc } from '../../../../helpers/networkSrc';
 import iconCheck from '../../../../images/icons/check.svg';
+import { explorerTxUrl } from '../../../../helpers/url';
 
 const useStyles = makeStyles(styles);
 
@@ -109,7 +110,7 @@ export const DestChainStatus = memo(function DestChainStatus() {
       {!txData.error && txData.swapTx && (
         <MuiButton
           className={classes.redirectLinkSuccess}
-          href={destChain.explorerUrl + '/tx/' + txData.swapTx}
+          href={explorerTxUrl(destChain, txData.swapTx)}
           target="_blank"
         >
           {t('Transactn-View')} {<OpenInNewRoundedIcon htmlColor="#59A662" fontSize="inherit" />}

--- a/src/components/Stepper/components/TransactionLink/TransactionLink.tsx
+++ b/src/components/Stepper/components/TransactionLink/TransactionLink.tsx
@@ -5,6 +5,7 @@ import { selectChainById } from '../../../../features/data/selectors/chains';
 import { styles } from './styles';
 import { useAppSelector } from '../../../../store';
 import { selectStepperChainId } from '../../../../features/data/selectors/stepper';
+import { explorerTxUrl } from '../../../../helpers/url';
 
 const useStyles = makeStyles(styles);
 
@@ -30,7 +31,7 @@ export function TransactionLink() {
   return (
     <Button
       className={classes.redirectLinkSuccess}
-      href={chain.explorerUrl + '/tx/' + hash}
+      href={explorerTxUrl(chain, hash)}
       target="_blank"
     >
       {t('Transactn-View')} {<OpenInNewRoundedIcon htmlColor="#59A662" fontSize="inherit" />}

--- a/src/config/config.tsx
+++ b/src/config/config.tsx
@@ -583,6 +583,7 @@ export const config: Record<ChainConfig['id'], Omit<ChainConfig, 'id'>> = {
     chainId: 324,
     rpc: ['https://mainnet.era.zksync.io'],
     explorerUrl: 'https://explorer.zksync.io',
+    explorerTokenUrlTemplate: 'https://explorer.zksync.io/address/{address}',
     multicallAddress: '0x1E9231Cc9782D9F8e213736F6dAC00020D8271cB',
     appMulticallContractAddress: '0x5479d2A10e60110F4728d910b5321Af4B78c30E4',
     providerName: 'zkSync',

--- a/src/features/data/apis/config-types.ts
+++ b/src/features/data/apis/config-types.ts
@@ -128,6 +128,9 @@ export interface ChainConfig {
   chainId: number;
   rpc: string[];
   explorerUrl: string;
+  explorerAddressUrlTemplate?: string;
+  explorerTokenUrlTemplate?: string;
+  explorerTxUrlTemplate?: string;
   multicallAddress: string;
   appMulticallContractAddress: string;
   providerName: string;

--- a/src/features/data/apis/config.ts
+++ b/src/features/data/apis/config.ts
@@ -26,7 +26,15 @@ import type { MigrationConfig } from '../reducers/wallet/migration';
  */
 export class ConfigAPI {
   public async fetchChainConfigs(): Promise<ChainConfig[]> {
-    return Object.entries(chainConfigs).map(([id, chain]) => ({ id, ...chain }));
+    return Object.entries(chainConfigs).map(([id, chain]) => ({
+      id,
+      ...chain,
+      explorerTokenUrlTemplate:
+        chain.explorerTokenUrlTemplate || `${chain.explorerUrl}/token/{address}`,
+      explorerAddressUrlTemplate:
+        chain.explorerAddressUrlTemplate || `${chain.explorerUrl}/address/{address}`,
+      explorerTxUrlTemplate: chain.explorerTxUrlTemplate || `${chain.explorerUrl}/tx/{hash}`,
+    }));
   }
 
   public async fetchFeaturedVaults(): Promise<FeaturedVaultConfig> {

--- a/src/features/data/entities/chain.ts
+++ b/src/features/data/entities/chain.ts
@@ -9,4 +9,12 @@ import type { ChainConfig } from '../apis/config-types';
  * We give another name to "chainId" to avoid any confusion between
  * beefy chain id ("harmony", "bsc") and the network chain id (8, 16, etc)
  */
-export type ChainEntity = Omit<ChainConfig, 'chainId'> & { networkChainId: number };
+export type ChainEntity = Omit<
+  ChainConfig,
+  'chainId' | 'explorerTokenUrlTemplate' | 'explorerAddressUrlTemplate' | 'explorerTxUrlTemplate'
+> & {
+  networkChainId: number;
+  explorerTokenUrlTemplate: string;
+  explorerAddressUrlTemplate: string;
+  explorerTxUrlTemplate: string;
+};

--- a/src/features/treasury/components/ExplorerLinks/ExplorerLinks.tsx
+++ b/src/features/treasury/components/ExplorerLinks/ExplorerLinks.tsx
@@ -10,6 +10,7 @@ import { selectChainById } from '../../../data/selectors/chains';
 import { selectTreasuryWalletAddressesByChainId } from '../../../data/selectors/treasury';
 import { styles } from './styles';
 import iconExternalLink from '../../../../images/icons/external-link.svg';
+import { explorerAddressUrl } from '../../../../helpers/url';
 
 const useStyles = makeStyles(styles);
 
@@ -51,7 +52,7 @@ export const ExplorerLinks = memo<ExplorerLinkProps>(function ExplorerLinks({ ch
             return (
               <a
                 key={wallet.address}
-                href={`${chain.explorerUrl}/address/${wallet.address}`}
+                href={explorerAddressUrl(chain, wallet.address)}
                 target="_blank"
                 rel="noopener noreferrer"
                 className={classes.item}

--- a/src/features/vault/components/AddTokenToWallet/AddTokenToWallet.tsx
+++ b/src/features/vault/components/AddTokenToWallet/AddTokenToWallet.tsx
@@ -12,6 +12,7 @@ import { selectChainById } from '../../../data/selectors/chains';
 import { selectCurrentChainId, selectIsWalletConnected } from '../../../data/selectors/wallet';
 import { ReactComponent as PlusIcon } from '../../../../images/icons/plus.svg';
 import { styles } from './styles';
+import { explorerTokenUrl } from '../../../../helpers/url';
 
 const useStyles = makeStyles(styles);
 
@@ -49,8 +50,6 @@ export const AddTokenToWallet = memo<AddTokenToWalletProps>(function AddTokenToW
     }
   }, [chainId, token.address, token.decimals, token.id, token.symbol]);
 
-  const explorerUrl = chain.explorerUrl + '/address/' + token.address;
-
   const shouldShowAddButton = isWalletConnected && isWalletOnSameChain;
 
   return (
@@ -66,7 +65,11 @@ export const AddTokenToWallet = memo<AddTokenToWalletProps>(function AddTokenToW
             <PlusIcon className={classes.icon} />
           </Button>
         )}
-        <LinkButton className={classes.linkButtonBg} href={explorerUrl} text={t('Explorer')} />
+        <LinkButton
+          className={classes.linkButtonBg}
+          href={explorerTokenUrl(chain, token.address)}
+          text={t('Explorer')}
+        />
       </div>
     </div>
   );

--- a/src/features/vault/components/GovDetailsCard/GovDetailsCard.tsx
+++ b/src/features/vault/components/GovDetailsCard/GovDetailsCard.tsx
@@ -8,6 +8,7 @@ import { selectTokenByAddress } from '../../../data/selectors/tokens';
 import { useAppSelector } from '../../../../store';
 import { LinkButton } from '../../../../components/LinkButton';
 import { selectChainById } from '../../../data/selectors/chains';
+import { explorerAddressUrl } from '../../../../helpers/url';
 
 const useStyles = makeStyles(styles);
 export const GovDetailsCard = ({ vaultId }: { vaultId: VaultGov['id'] }) => {
@@ -24,7 +25,7 @@ export const GovDetailsCard = ({ vaultId }: { vaultId: VaultGov['id'] }) => {
       <CardHeader className={classes.header}>
         <CardTitle title={t('Gov-Pool')} />
         <LinkButton
-          href={`${chain.explorerUrl}/address/${vault.earnContractAddress}`}
+          href={explorerAddressUrl(chain, vault.earnContractAddress)}
           text={t('Strat-PoolAddress')}
         />
       </CardHeader>

--- a/src/features/vault/components/StrategyCard/StrategyCard.tsx
+++ b/src/features/vault/components/StrategyCard/StrategyCard.tsx
@@ -15,6 +15,7 @@ import { selectChainById } from '../../../data/selectors/chains';
 import { selectIsVaultBoosted } from '../../../data/selectors/boosts';
 import { StatLoader } from '../../../../components/StatLoader';
 import { useAppSelector } from '../../../../store';
+import { explorerAddressUrl } from '../../../../helpers/url';
 
 const useStyles = makeStyles(styles);
 
@@ -42,14 +43,11 @@ function StrategyCardComponent({ vaultId }: { vaultId: VaultEntity['id'] }) {
         </div>
         <div className={classes.cardActions}>
           <div className={classes.cardAction}>
-            <LinkButton
-              href={`${chain.explorerUrl}/address/${stratAddr}`}
-              text={t('Strat-Address')}
-            />
+            <LinkButton href={explorerAddressUrl(chain, stratAddr)} text={t('Strat-Address')} />
           </div>
           <div className={classes.cardAction}>
             <LinkButton
-              href={`${chain.explorerUrl}/address/${vault.earnContractAddress}`}
+              href={explorerAddressUrl(chain, vault.earnContractAddress)}
               text={t('Strat-AddressVault')}
             />
           </div>

--- a/src/features/vault/components/TokenCard/TokenCard.tsx
+++ b/src/features/vault/components/TokenCard/TokenCard.tsx
@@ -17,6 +17,7 @@ import { useAppDispatch, useAppSelector } from '../../../../store';
 import { AssetsImage } from '../../../../components/AssetsImage';
 import { selectBridgeByIdIfKnown } from '../../../data/selectors/bridges';
 import { BridgeTag, NativeTag } from '../BridgeTag';
+import { explorerTokenUrl } from '../../../../helpers/url';
 
 const useStyles = makeStyles(styles);
 
@@ -49,7 +50,7 @@ function TokenCardDisplay({ token }: { token: TokenEntity }) {
           {isErc20 && (
             <LinkButton
               hideIconOnMobile={true}
-              href={`${chain.explorerUrl}/token/${token.address}`}
+              href={explorerTokenUrl(chain, token.address)}
               text={t('Token-Contract')}
             />
           )}

--- a/src/helpers/url.ts
+++ b/src/helpers/url.ts
@@ -1,0 +1,13 @@
+import type { ChainEntity } from '../features/data/entities/chain';
+
+export function explorerTokenUrl(chain: ChainEntity, tokenAddress: string) {
+  return chain.explorerTokenUrlTemplate.replace('{address}', tokenAddress);
+}
+
+export function explorerAddressUrl(chain: ChainEntity, contractAddress: string) {
+  return chain.explorerAddressUrlTemplate.replace('{address}', contractAddress);
+}
+
+export function explorerTxUrl(chain: ChainEntity, txHash: string) {
+  return chain.explorerTxUrlTemplate.replace('{hash}', txHash);
+}

--- a/src/helpers/url.ts
+++ b/src/helpers/url.ts
@@ -4,8 +4,8 @@ export function explorerTokenUrl(chain: ChainEntity, tokenAddress: string) {
   return chain.explorerTokenUrlTemplate.replace('{address}', tokenAddress);
 }
 
-export function explorerAddressUrl(chain: ChainEntity, contractAddress: string) {
-  return chain.explorerAddressUrlTemplate.replace('{address}', contractAddress);
+export function explorerAddressUrl(chain: ChainEntity, address: string) {
+  return chain.explorerAddressUrlTemplate.replace('{address}', address);
 }
 
 export function explorerTxUrl(chain: ChainEntity, txHash: string) {


### PR DESCRIPTION
# Changes

Adds 3 new **optional** config entries for chain configuration:

### `explorerTokenUrlTemplate`
default: `${chain.explorerUrl}/token/{address}`
helper: `explorerTokenUrl(chain: ChainEntity, tokenAddress: string)`
variables:
`{address}` is replaced by the `tokenAddress` passed to the helper

### `explorerTokenAddressTemplate`
default: `${chain.explorerUrl}/address/{address}`
helper: `explorerAddressUrl(chain: ChainEntity, address: string)`
variables:
`{address}` is replaced by the `address` passed to the helper

### `explorerTxUrlTemplate`
default: `${chain.explorerUrl}/tx/{hash}`
helper: `explorerTxUrl(chain: ChainEntity, txHash: string)`
variables:
`{hash}` is replaced by the `txHash` passed to the help

# Config

This PR sets `explorerTokenUrlTemplate: 'https://explorer.zksync.io/address/{address}'` for ZkSync Era as there is no /token/ endpoint on explorer.zksync.io
