### PR TITLE
Enable eip1559 on base

### DIFF
--- a/src/config/config.tsx
+++ b/src/config/config.tsx
@@ -654,7 +654,11 @@ export const config: Record<ChainConfig['id'], Omit<ChainConfig, 'id'>> = {
       blockExplorerUrls: ['https://basescan.org/'],
     },
     gas: {
-      type: 'standard',
+      type: 'eip1559',
+      blocks: 100,
+      percentile: 0.7,
+      baseSafetyMargin: 0.2,
+      priorityMinimum: '10000000', // 0.01 gwei
     },
     stableCoins: ['USDbC', 'DAI', 'bsUSD', 'axlUSDC', 'MIM', 'USD+', 'DAI+'],
   },


### PR DESCRIPTION
base fee: 70th percentile of last 100 blocks +20% safety margin
tip: 70th percentile of last 100 blocks, min 0.01gwei (see note)

`eth_feeHistory` is correctly returning baseFeePerGas for blocks (around 0.000000059 Gwei), but most of the block's rewards are being returned as 0 when in reality the tip for txs in each block has a median of around 1.5 Gwei, so I've set minimum to 0.01 Gwei - **we should monitor the situation in case this ends up being too low.**

Rabby does not have eip1559 controls for base so test with MetaMask.

Example tx: Base: 0.000000064 Gwei | Max: 0.01000008 Gwei | Max Priority: 0.01 Gwei