### PR TITLE
Remove duplicate dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "husky": ">=6",
     "lint-staged": ">=10",
     "madge": "^5.0.1",
-    "p-queue": "^6.6.2",
     "prettier": "^2.8.8",
     "rollup-plugin-polyfill-node": "^0.12.0",
     "rollup-plugin-visualizer": "^5.9.0",


### PR DESCRIPTION
`p-queue` is already used in `package.json` as a non-dev dependency, removing the duplicate allows [bun](https://github.com/oven-sh/bun) to be used as an alternative package manager ([significantly faster than yarn](https://bun.sh/package-manager))