### PR TITLE
Fix gas price estimate

### DIFF
--- a/src/features/data/apis/gas-prices/gas-prices.ts
+++ b/src/features/data/apis/gas-prices/gas-prices.ts
@@ -125,7 +125,7 @@ export class EIP1559GasPricer implements IGasPricer {
     const feeHistory = await web3.eth.getBeefyFeeHistory(this.blockCount, 'latest', [
       this.percentile,
     ]);
-    const nextBlock = await web3.eth.getBlock('pending');
+    const nextBlock = await web3.eth.getBlock('latest');
 
     const sortedBaseFees = sortWith(feeHistory.baseFeePerGas, compareBigNumber);
     const initialBaseFee = BigNumber.max(


### PR DESCRIPTION
Use latest block as not all rpcs support pending

Fixes this
![image](https://github.com/beefyfinance/beefy-v2/assets/55021052/7bb9fa60-f7db-4e35-9c0a-d1697e8d207c)
