### PR TITLE
Change Kava RPC to evm2.kava.io

### DIFF
--- a/src/config/config.tsx
+++ b/src/config/config.tsx
@@ -541,7 +541,7 @@ export const config: Record<ChainConfig['id'], Omit<ChainConfig, 'id'>> = {
   kava: {
     name: 'Kava',
     chainId: 2222,
-    rpc: ['https://kava-evm.publicnode.com'],
+    rpc: ['https://evm2.kava.io'],
     explorerUrl: 'https://explorer.kava.io',
     multicallAddress: '0x13C6bCC2411861A31dcDC2f990ddbe2325482222',
     appMulticallContractAddress: '0x41D44B276904561Ac51855159516FD4cB2c90968',
@@ -554,7 +554,7 @@ export const config: Record<ChainConfig['id'], Omit<ChainConfig, 'id'>> = {
         symbol: 'KAVA',
         decimals: 18,
       },
-      rpcUrls: ['https://kava-evm.publicnode.com'],
+      rpcUrls: ['https://evm2.kava.io'],
       blockExplorerUrls: ['https://explorer.kava.io/'],
     },
     gas: {


### PR DESCRIPTION
`https://kava-evm.publicnode.com` is throwing errors on `eth_gasPrice` requests:

request:
```json
{"jsonrpc":"2.0","id":4938331598874094,"method":"eth_gasPrice","params":[]}
```

response:
```json
{
    "jsonrpc": "2.0",
    "id": 4938331598874094,
    "error": {
        "code": -32000,
        "message": "method handler crashed"
    }
}
```