### PR TITLE
Disable asset inline

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
   },
   build: {
     outDir: 'build',
+    assetsInlineLimit: 0,
     commonjsOptions: {
       transformMixedEsModules: true,
     },


### PR DESCRIPTION
So we have a real url for each asset (e.g. from when adding token to a wallet)

To test:
1. check add to wallet for e.g. WKAVA on boost
2. make sure loading isn't slow in general