### PR TITLE
Fix intermittent dashboard crash

### DIFF
--- a/src/features/data/actions/wallet.ts
+++ b/src/features/data/actions/wallet.ts
@@ -57,7 +57,7 @@ export const initDashboardByAddress = createAsyncThunk<
   for (const chainId of chains) {
     dispatch(fetchAllBalanceAction({ chainId, walletAddress: lowerCaseAddress }));
   }
-  dispatch(fetchWalletTimeline({ address }));
+  dispatch(fetchWalletTimeline({ address: lowerCaseAddress }));
 
   return { address: lowerCaseAddress };
 });

--- a/src/features/data/selectors/analytics.ts
+++ b/src/features/data/selectors/analytics.ts
@@ -16,20 +16,29 @@ export const selectUserDepositedTimelineByVaultId = createCachedSelector(
   (state: BeefyState, _vaultId: VaultEntity['id'], _address?: string) => state.user.analytics,
   (state: BeefyState, vaultId: VaultEntity['id'], _address?: string) => vaultId,
   (walletAddress, analyticsState, vaultId) =>
-    analyticsState.byAddress[walletAddress?.toLocaleLowerCase()]?.timeline.byVaultId[vaultId] || []
+    analyticsState.byAddress[walletAddress?.toLowerCase()]?.timeline.byVaultId[vaultId] || []
 )((state: BeefyState, vaultId: VaultEntity['id'], _address?: string) => vaultId);
 
 export const selectIsDashboardDataLoadedByAddress = (state: BeefyState, walletAddress: string) => {
-  const dataByAddress = state.ui.dataLoader.byAddress[walletAddress?.toLocaleLowerCase()];
+  if (!walletAddress) {
+    return false;
+  }
 
-  const timelineLoaded = selectIsAnalyticsLoadedByAddress(state, walletAddress);
+  const addressLower = walletAddress.toLowerCase();
+  const timelineLoaded = selectIsAnalyticsLoadedByAddress(state, addressLower);
+  if (!timelineLoaded) {
+    return false;
+  }
 
-  if (timelineLoaded) {
-    for (const chainId of Object.values(dataByAddress.byChainId)) {
-      if (chainId.balance.alreadyLoadedOnce && chainId.balance.status === 'fulfilled') {
-        // if any chain has already loaded, then  data is available
-        return true;
-      }
+  const dataByAddress = state.ui.dataLoader.byAddress[addressLower];
+  if (!dataByAddress) {
+    return false;
+  }
+
+  for (const chainId of Object.values(dataByAddress.byChainId)) {
+    if (chainId.balance.alreadyLoadedOnce && chainId.balance.status === 'fulfilled') {
+      // if any chain has already loaded, then  data is available
+      return true;
     }
   }
 
@@ -147,9 +156,8 @@ export const selectUnderlyingToUsdTimebucketByVaultId = (
 ) => {
   const walletAddress = address || selectWalletAddress(state);
   return (
-    state.user.analytics.byAddress[walletAddress?.toLocaleLowerCase()]?.underlyingToUsd.byVaultId[
-      vaultId
-    ]?.byTimebucket[timebucket] || {
+    state.user.analytics.byAddress[walletAddress?.toLowerCase()]?.underlyingToUsd.byVaultId[vaultId]
+      ?.byTimebucket[timebucket] || {
       data: [],
       status: 'idle',
     }


### PR DESCRIPTION
Depending on load order, the `selectIsDashboardDataLoadedByAddress` selector may run before `state.ui.dataLoader.byAddress[address]` exists, causing a crash when trying to access data there.