### PR TITLE
fix analytics shares address key

### DIFF
--- a/src/features/data/selectors/analytics.ts
+++ b/src/features/data/selectors/analytics.ts
@@ -143,8 +143,9 @@ export const selectShareToUnderlyingTimebucketByVaultId = (
 ) => {
   const walletAddress = address || selectWalletAddress(state);
   return (
-    state.user.analytics.byAddress[walletAddress]?.shareToUnderlying.byVaultId[vaultId]
-      ?.byTimebucket[timebucket] || {
+    state.user.analytics.byAddress[walletAddress?.toLowerCase()]?.shareToUnderlying.byVaultId[
+      vaultId
+    ]?.byTimebucket[timebucket] || {
       data: [],
       status: 'idle',
     }


### PR DESCRIPTION
could stop the PNL chart appearing when using __view_as