### PR TITLE
Fix: Hide BIFI on onramp tokens list

### DIFF
--- a/src/features/on-ramp/components/OnRamp/components/TokenStep/TokenStep.tsx
+++ b/src/features/on-ramp/components/OnRamp/components/TokenStep/TokenStep.tsx
@@ -55,7 +55,11 @@ const ListItem = memo<ItemInnerProps>(function ListItem({ value }) {
 
 const TokenSelector = memo<{ fiat: string }>(function TokenSelector({ fiat }) {
   const tokens = useAppSelector(state => selectSupportedTokensForFiat(state, fiat));
-  const sortedTokens = useMemo(() => [...tokens].sort(), [tokens]);
+  const sortedTokens = useMemo(
+    () => [...tokens].filter(token => token !== 'BIFI').sort(),
+    [tokens]
+  );
+
   const dispatch = useAppDispatch();
 
   const handleSelect = useCallback(


### PR DESCRIPTION
This is due transak is still offering old BIFI