### PR TITLE
Set kava rpc

### DIFF
--- a/src/config/config.tsx
+++ b/src/config/config.tsx
@@ -550,7 +550,7 @@ export const config: Record<ChainConfig['id'], Omit<ChainConfig, 'id'>> = {
   kava: {
     name: 'Kava',
     chainId: 2222,
-    rpc: ['https://kava-evm.publicnode.com'],
+    rpc: ['https://evm.kava.io'],
     explorerUrl: 'https://explorer.kava.io',
     multicallAddress: '0x13C6bCC2411861A31dcDC2f990ddbe2325482222',
     appMulticallContractAddress: '0x41D44B276904561Ac51855159516FD4cB2c90968',
@@ -563,7 +563,7 @@ export const config: Record<ChainConfig['id'], Omit<ChainConfig, 'id'>> = {
         symbol: 'KAVA',
         decimals: 18,
       },
-      rpcUrls: ['https://kava-evm.publicnode.com'],
+      rpcUrls: ['https://evm.kava.io'],
       blockExplorerUrls: ['https://explorer.kava.io/'],
     },
     gas: {


### PR DESCRIPTION
https://kava-evm.publicnode.com seems to be only one with the problem

### Request
```json
{
  "id": 1,
  "jsonrpc": "2.0",
  "method": "eth_gasPrice",
  "params": []
}
```

### Responses
https://evm.kava.io
`{ jsonrpc: '2.0', id: 1, result: '0x3b9aca00' }`

https://evm2.kava.io
`{ jsonrpc: '2.0', id: 1, result: '0x3b9aca00' }`

https://evm.kava.chainstacklabs.com
`{ jsonrpc: '2.0', id: 1, result: '0x3b9aca00' }`

https://kava-evm.publicnode.com

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": -32000,
    "message": "method handler crashed"
  }
}
```