### PR TITLE
fix: use date/shareDiff for old txs without a tx hash

### DIFF
--- a/src/features/dashboard/components/UserVaults/components/VaultTransactions/components/Transaction/Transaction.tsx
+++ b/src/features/dashboard/components/UserVaults/components/VaultTransactions/components/Transaction/Transaction.tsx
@@ -23,6 +23,7 @@ interface TransactionProps {
   data: VaultTimelineAnalyticsEntity;
   tokenDecimals: number;
 }
+
 export const Transaction = memo<TransactionProps>(function Transaction({ data, tokenDecimals }) {
   const classes = useStyles();
   const chainId = data.source?.chain || data.chain;
@@ -52,14 +53,18 @@ export const Transaction = memo<TransactionProps>(function Transaction({ data, t
           height={24}
           className={classes.network}
         />
-        <a
-          href={explorerTxUrl(chain, transactionHash)}
-          target={'_blank'}
-          rel={'noopener'}
-          className={classes.link}
-        >
-          {formatISO9075(datetime)}
-        </a>
+        {transactionHash ? (
+          <a
+            href={explorerTxUrl(chain, transactionHash)}
+            target={'_blank'}
+            rel={'noopener'}
+            className={classes.link}
+          >
+            {formatISO9075(datetime)}
+          </a>
+        ) : (
+          formatISO9075(datetime)
+        )}
       </div>
       <InfoGrid>
         {/*Amount */}
@@ -142,14 +147,18 @@ export const TransactionMobile = memo<TransactionProps>(function TransactionMobi
         } ${diff}`}</div>
         {/* Date */}
         <div className={classes.statMobile}>
-          <a
-            href={explorerTxUrl(chain, transactionHash)}
-            target={'_blank'}
-            rel={'noopener'}
-            className={classes.link}
-          >
-            {formatISO9075(datetime, { representation: 'date' })}
-          </a>
+          {transactionHash ? (
+            <a
+              href={explorerTxUrl(chain, transactionHash)}
+              target={'_blank'}
+              rel={'noopener'}
+              className={classes.link}
+            >
+              {formatISO9075(datetime, { representation: 'date' })}
+            </a>
+          ) : (
+            formatISO9075(datetime, { representation: 'date' })
+          )}
         </div>
         <div className={clsx(classes.statMobile, classes.textDark)}>
           {formatISO9075(datetime, { representation: 'time' })}

--- a/src/features/data/entities/analytics.ts
+++ b/src/features/data/entities/analytics.ts
@@ -21,6 +21,7 @@ type VTACOptionalBigNumber = ChangeTypeOfKeys<
 type VTACWithDateTime = ChangeTypeOfKeys<VTACOptionalBigNumber, 'datetime', Date>;
 
 export type VaultTimelineAnalyticsEntity = VTACWithDateTime & {
+  transactionId: string;
   source?: {
     productKey: string;
     displayName: string;

--- a/src/features/data/reducers/analytics.ts
+++ b/src/features/data/reducers/analytics.ts
@@ -75,6 +75,9 @@ export const analyticsSlice = createSlice({
       );
       // Grab all the tx hashes from the boost txs, and filter out any vault txs that have the same hash
       const boostTxHashes = new Set(boostTxs.map(tx => tx.transactionHash));
+      boostTxHashes.delete(undefined);
+      boostTxHashes.delete(null);
+
       const vaultIdsWithMerges = new Set<string>();
       const vaultTxsIgnoringBoosts = vaultTxs.filter(tx => {
         if (boostTxHashes.has(tx.transactionHash)) {

--- a/src/features/data/reducers/analytics.ts
+++ b/src/features/data/reducers/analytics.ts
@@ -73,14 +73,12 @@ export const analyticsSlice = createSlice({
       const [boostTxs, vaultTxs] = partition(timeline, tx =>
         tx.productKey.startsWith('beefy:boost')
       );
-      // Grab all the tx hashes from the boost txs, and filter out any vault txs that have the same hash
-      const boostTxHashes = new Set(boostTxs.map(tx => tx.transactionHash));
-      boostTxHashes.delete(undefined);
-      boostTxHashes.delete(null);
 
+      // Grab all the tx hashes from the boost txs, and filter out any vault txs that have the same hash
+      const boostTxIds = new Set(boostTxs.map(tx => tx.transactionId));
       const vaultIdsWithMerges = new Set<string>();
       const vaultTxsIgnoringBoosts = vaultTxs.filter(tx => {
-        if (boostTxHashes.has(tx.transactionHash)) {
+        if (boostTxIds.has(tx.transactionId)) {
           vaultIdsWithMerges.add(tx.displayName);
           return false;
         }


### PR DESCRIPTION
old txs do not have a recorded transaction_hash in databarn, this pr falls back to using date+shareDiff as a key when a tx hash is missing