### PR TITLE
Support multi lines token description

### DIFF
--- a/src/features/vault/components/TokenCard/styles.tsx
+++ b/src/features/vault/components/TokenCard/styles.tsx
@@ -66,5 +66,6 @@ export const styles = (theme: Theme) => ({
     ...theme.typography['body-lg'],
     color: theme.palette.text.middle,
     marginTop: '16px',
+    whiteSpace: 'pre-line' as const,
   },
 });


### PR DESCRIPTION
 - Add Support to breakline inside tokens descriptions
 eg 
 ```ts
 token:{
  ...,
  description: 'description\nmoreinfo'
 }
 ```
 
 will show
 ```js
 description
 moreinfo
 ```
 