### PR TITLE
Fix: Make address book source of truth for token symbols

### DIFF
--- a/src/features/data/reducers/tokens.ts
+++ b/src/features/data/reducers/tokens.ts
@@ -332,12 +332,21 @@ function addAddressBookToState(
     } else {
       const existingToken = sliceState.byChainId[chainId].byAddress[token.address.toLowerCase()];
 
-      // Addressbook is source of truth for oracle ids
+      // Address book is source of truth for oracle ids
       if (token.oracleId) {
         existingToken.oracleId = token.oracleId;
       } else {
         console.error(
           `[Addressbook] ${existingToken.id}/${existingToken.address}/${existingToken.chainId} has no oracleId`
+        );
+      }
+
+      // Address book is source of truth for symbols
+      if (token.symbol) {
+        existingToken.symbol = token.symbol;
+      } else {
+        console.error(
+          `[Addressbook] ${existingToken.id}/${existingToken.address}/${existingToken.chainId} has no symbol`
         );
       }
 


### PR DESCRIPTION
If vault files load before address book, tokens will have a symbol equal to their id, this lets the address book overwrite them