### PR TITLE
Fix Velodrome Vault URLs

### DIFF
--- a/scripts/setVaultUrls.ts
+++ b/scripts/setVaultUrls.ts
@@ -124,19 +124,12 @@ const URLS: ChainProviderUrls = {
     velodrome: [
       {
         condition: (vault: VaultConfig) =>
-          vault.id.startsWith('velodrome-') && !vault.id.startsWith('velodrome-v2-'),
-        buyTokenUrl: 'https://velodrome.finance/swap?from={token0}&to={token1}',
-        addLiquidityUrl: 'https://v1.velodrome.finance/liquidity/manage?address={lp}',
-        removeLiquidityUrl: 'https://v1.velodrome.finance/liquidity/manage?address={lp}',
-      },
-      {
-        condition: (vault: VaultConfig) =>
           vault.id.startsWith('velodrome-v2-') && vault.token.includes(' sLP'),
         buyTokenUrl:
           'https://velodrome.finance/swap?from={token0:wrapped:lower}&to={token1:wrapped:lower}',
         addLiquidityUrl:
-          'https://velodrome.finance/deposit?token0={token0:wrapped:lower}&token1={token1:wrapped:lower}&stable=true',
-        removeLiquidityUrl: 'https://velodrome.finance/withdraw?pool={lp:lower}',
+          'https://velodrome.finance/deposit?token0={token0:wrapped}&token1={token1:wrapped}&type=0',
+        removeLiquidityUrl: 'https://velodrome.finance/withdraw?pool={lp}',
       },
       {
         condition: (vault: VaultConfig) =>
@@ -144,8 +137,8 @@ const URLS: ChainProviderUrls = {
         buyTokenUrl:
           'https://velodrome.finance/swap?from={token0:wrapped:lower}&to={token1:wrapped:lower}',
         addLiquidityUrl:
-          'https://velodrome.finance/deposit?token0={token0:wrapped:lower}&token1={token1:wrapped:lower}&stable=false',
-        removeLiquidityUrl: 'https://velodrome.finance/withdraw?pool={lp:lower}',
+          'https://velodrome.finance/deposit?token0={token0:wrapped}&token1={token1:wrapped}&type=-1',
+        removeLiquidityUrl: 'https://velodrome.finance/withdraw?pool={lp}',
       },
     ],
     curve: {

--- a/scripts/setVaultUrls.ts
+++ b/scripts/setVaultUrls.ts
@@ -124,6 +124,13 @@ const URLS: ChainProviderUrls = {
     velodrome: [
       {
         condition: (vault: VaultConfig) =>
+          vault.id.startsWith('velodrome-') && !vault.id.startsWith('velodrome-v2-'),
+        buyTokenUrl: 'https://velodrome.finance/swap?from={token0}&to={token1}',
+        addLiquidityUrl: 'https://v1.velodrome.finance/liquidity/manage?address={lp}',
+        removeLiquidityUrl: 'https://v1.velodrome.finance/liquidity/manage?address={lp}',
+      },
+      {
+        condition: (vault: VaultConfig) =>
           vault.id.startsWith('velodrome-v2-') && vault.token.includes(' sLP'),
         buyTokenUrl:
           'https://velodrome.finance/swap?from={token0:wrapped:lower}&to={token1:wrapped:lower}',

--- a/src/config/boost/partners.json
+++ b/src/config/boost/partners.json
@@ -264,7 +264,7 @@
   "velodrome": {
     "title": "Velodrome",
     "text": "Velodrome Finance, at its core, is a solution for protocols on Optimism to properly incentivize liquidity for their own use cases. Building on top of the groundwork laid out by Solidly, their team has addressed that first iteration's core issues to realize its full potential.",
-    "website": "https://app.velodrome.finance/swap",
+    "website": "https://velodrome.finance/swap",
     "social": {
       "discord": "https://discord.com/invite/velodrome",
       "twitter": "https://twitter.com/VelodromeFi"

--- a/src/config/vault/optimism.json
+++ b/src/config/vault/optimism.json
@@ -18,7 +18,8 @@
     "assets": ["USDC", "OP"],
     "risks": ["COMPLEXITY_LOW", "IL_HIGH", "MCAP_LARGE", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85&token1=0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb&stable=false",
+    "buyTokenUrl": "https://velodrome.finance/swap?from=0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85&to=0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85&token1=0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x67F56Ac099F11aD5F65E2ec804f75F2cEa6ab8C5",
     "network": "optimism",
     "zaps": [
@@ -47,7 +48,8 @@
     "assets": ["USDC", "wstETH"],
     "risks": ["COMPLEXITY_LOW", "IL_HIGH", "MCAP_LARGE", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85&token1=0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb&stable=false",
+    "buyTokenUrl": "https://velodrome.finance/swap?from=0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85&to=0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85&token1=0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x38133C2775Ed3F8C698d5741a24bA833f8724e7A",
     "network": "optimism",
     "zaps": [
@@ -76,6 +78,7 @@
     "assets": ["USDC", "DOLA"],
     "risks": ["COMPLEXITY_LOW", "IL_NONE", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
+    "buyTokenUrl": "https://velodrome.finance/swap?from=0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85&to=0x8aE125E8653821E851F12A49F7765db9a9ce7384",
     "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85&token1=0x8aE125E8653821E851F12A49F7765db9a9ce7384&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xA56a25Dee5B3199A9198Bbd48715EE3D0ed98378",
     "network": "optimism",
@@ -128,6 +131,7 @@
     "assets": ["USDC", "opUSDCe"],
     "risks": ["COMPLEXITY_LOW", "IL_NONE", "MCAP_LARGE", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
+    "buyTokenUrl": "https://velodrome.finance/swap?from=0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85&to=0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
     "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85&token1=0x7F5c764cBc14f9669B88837ca1490cCa17c31607&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x36E3c209B373b861c185ecdBb8b2EbDD98587BDb",
     "network": "optimism",
@@ -163,6 +167,7 @@
       "OVER_COLLAT_ALGO_STABLECOIN"
     ],
     "strategyTypeId": "lp",
+    "buyTokenUrl": "https://velodrome.finance/swap?from=0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85&to=0x73cb180bf0521828d8849bc8CF2B920918e23032",
     "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85&token1=0x73cb180bf0521828d8849bc8CF2B920918e23032&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x46e1B51e07851301f025ffeA506b140dB80a214A",
     "network": "optimism",
@@ -399,7 +404,7 @@
     "risks": ["COMPLEXITY_LOW", "IL_HIGH", "MCAP_MEDIUM", "AUDIT", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x3a18dcc9745edcd1ef33ecb93b0b6eba5671e7ca&to=0x9560e827af36c94d2ac33a39bce1fe78631088db",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x3a18dcc9745edcd1ef33ecb93b0b6eba5671e7ca&token1=0x9560e827af36c94d2ac33a39bce1fe78631088db&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x3a18dcc9745edcd1ef33ecb93b0b6eba5671e7ca&token1=0x9560e827af36c94d2ac33a39bce1fe78631088db&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x18c830f6a32a06cf2ac4262e977a096f12bdab8d",
     "network": "optimism",
     "zaps": [
@@ -434,7 +439,7 @@
   },
   {
     "id": "velodrome-v2-kuji-weth",
-    "name": "KUJI-ETH vLP",
+    "name": "KUJI-ETH vLP V2",
     "type": "standard",
     "token": "vAMM-KUJI-ETH",
     "tokenAddress": "0x763C9dC392B6BEFe79Fa227056dD9279bAbb4E14",
@@ -458,8 +463,9 @@
       "CONTRACTS_VERIFIED"
     ],
     "strategyTypeId": "lp",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x3a18dcc9745edcd1ef33ecb93b0b6eba5671e7ca&token1=eth&stable=false",
-    "removeLiquidityUrl": "https://velodrome.finance/withdraw",
+    "buyTokenUrl": "https://velodrome.finance/swap?from=eth&to=0x3a18dcc9745edcd1ef33ecb93b0b6eba5671e7ca",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x3a18dcc9745edcd1ef33ecb93b0b6eba5671e7ca&token1=eth&type=-1",
+    "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x763C9dC392B6BEFe79Fa227056dD9279bAbb4E14",
     "network": "optimism",
     "zaps": [
       {
@@ -590,7 +596,7 @@
   },
   {
     "id": "velodrome-v2-next-usdc",
-    "name": "NEXT-USDC.e vLP",
+    "name": "NEXT-USDC.e vLP V2",
     "type": "standard",
     "token": "vAMM-NEXT-USDCe",
     "tokenAddress": "0x1e7c5572B3D5942Cf5dabf61f5Ba3FbC6B65e921",
@@ -607,8 +613,9 @@
     "assets": ["NEXT", "opUSDCe"],
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x58b9cb810a68a7f3e1e4f8cb45d1b9b3c79705e8&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=false",
-    "removeLiquidityUrl": "https://velodrome.finance/withdraw",
+    "buyTokenUrl": "https://velodrome.finance/swap?from=0x58b9cb810a68a7f3e1e4f8cb45d1b9b3c79705e8&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x58b9cb810a68a7f3e1e4f8cb45d1b9b3c79705e8&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=-1",
+    "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x1e7c5572B3D5942Cf5dabf61f5Ba3FbC6B65e921",
     "network": "optimism",
     "zaps": [
       {
@@ -764,7 +771,7 @@
   },
   {
     "id": "velodrome-v2-wsteth-velo",
-    "name": "wstETH-VELO vLP",
+    "name": "wstETH-VELO vLP V2",
     "type": "standard",
     "token": "vAMM-wstETH-VELO",
     "tokenAddress": "0xCa72114b86Ac6d7Ab8D583c0E94C9A7DE7540610",
@@ -781,8 +788,9 @@
     "assets": ["VELOV2", "wstETH"],
     "risks": ["COMPLEXITY_LOW", "IL_HIGH", "MCAP_MEDIUM", "AUDIT", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x1f32b1c2345538c0c6f582fcb022739c4a194ebb&token1=0x9560e827af36c94d2ac33a39bce1fe78631088db&stable=false",
-    "removeLiquidityUrl": "https://velodrome.finance/withdraw",
+    "buyTokenUrl": "https://velodrome.finance/swap?from=0x1f32b1c2345538c0c6f582fcb022739c4a194ebb&to=0x9560e827af36c94d2ac33a39bce1fe78631088db",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x1f32b1c2345538c0c6f582fcb022739c4a194ebb&token1=0x9560e827af36c94d2ac33a39bce1fe78631088db&type=-1",
+    "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xCa72114b86Ac6d7Ab8D583c0E94C9A7DE7540610",
     "network": "optimism",
     "zaps": [
       {
@@ -900,7 +908,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0xc55e93c62874d8100dbd2dfe307edc1036ad5434&to=0x4200000000000000000000000000000000000006",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xc55e93c62874d8100dbd2dfe307edc1036ad5434&token1=0x4200000000000000000000000000000000000006&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xc55e93c62874d8100dbd2dfe307edc1036ad5434&token1=0x4200000000000000000000000000000000000006&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x6ed6df1c23c51cb7cc67a348cc8d9e6108ea3bfe",
     "network": "optimism",
     "zaps": [
@@ -981,7 +989,7 @@
   },
   {
     "id": "velodrome-v2-ovn-usd+",
-    "name": "OVN-USD+ vLP v2",
+    "name": "OVN-USD+ vLP V2",
     "type": "standard",
     "token": "vAMMV2-OVN/USD+",
     "tokenAddress": "0x844D7d2fCa6786Be7De6721AabdfF6957ACE73a0",
@@ -998,7 +1006,8 @@
     "assets": ["OVN", "USD+"],
     "risks": ["COMPLEXITY_LOW", "IL_HIGH", "MCAP_MEDIUM", "AUDIT", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x3b08fcd15280e7b5a6e404c4abb87f7c774d1b2e&token1=0x73cb180bf0521828d8849bc8cf2b920918e23032&stable=false",
+    "buyTokenUrl": "https://velodrome.finance/swap?from=0x3b08fcd15280e7b5a6e404c4abb87f7c774d1b2e&to=0x73cb180bf0521828d8849bc8cf2b920918e23032",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x3b08fcd15280e7b5a6e404c4abb87f7c774d1b2e&token1=0x73cb180bf0521828d8849bc8cf2b920918e23032&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x844D7d2fCa6786Be7De6721AabdfF6957ACE73a0",
     "network": "optimism",
     "zaps": [
@@ -1010,9 +1019,9 @@
   },
   {
     "id": "velodrome-v2-wsteth-pendle",
-    "name": "wstETH-PENDLE vLP v2",
+    "name": "wstETH-PENDLE vLP V2",
     "type": "standard",
-    "token": "wstETH-PENDLE vLP v2",
+    "token": "vAMMV2-wstETH/PENDLE",
     "tokenAddress": "0x7c9a7243F6A359781996822A141A28DC48AA258b",
     "tokenDecimals": 18,
     "tokenProviderId": "velodrome",
@@ -1028,7 +1037,7 @@
     "risks": ["COMPLEXITY_LOW", "IL_HIGH", "MCAP_MEDIUM", "AUDIT", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x1f32b1c2345538c0c6f582fcb022739c4a194ebb&to=0xbc7b1ff1c6989f006a1185318ed4e7b5796e66e1",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x1f32b1c2345538c0c6f582fcb022739c4a194ebb&token1=0xbc7b1ff1c6989f006a1185318ed4e7b5796e66e1&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x1f32b1c2345538c0c6f582fcb022739c4a194ebb&token1=0xbc7b1ff1c6989f006a1185318ed4e7b5796e66e1&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x7c9a7243f6a359781996822a141a28dc48aa258b",
     "network": "optimism",
     "zaps": [
@@ -1147,7 +1156,7 @@
     "risks": ["COMPLEXITY_LOW", "IL_HIGH", "MCAP_MICRO", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc&to=0x4200000000000000000000000000000000000006",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc&token1=0x4200000000000000000000000000000000000006&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc&token1=0x4200000000000000000000000000000000000006&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x0e88a5bff34d39da66bdd32b82dc89a32d7bb6c9",
     "network": "optimism",
     "zaps": [
@@ -1177,7 +1186,7 @@
     "risks": ["COMPLEXITY_LOW", "IL_NONE", "MCAP_SMALL", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x7f5c764cbc14f9669b88837ca1490cca17c31607&to=0xc03b43d492d904406db2d7d57e67c7e8234ba752",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x7f5c764cbc14f9669b88837ca1490cca17c31607&token1=0xc03b43d492d904406db2d7d57e67c7e8234ba752&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x7f5c764cbc14f9669b88837ca1490cca17c31607&token1=0xc03b43d492d904406db2d7d57e67c7e8234ba752&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x95a05d06decf8e1eb93ae09b612fbd342f2f9e2e",
     "network": "optimism",
     "zaps": [
@@ -1207,7 +1216,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_SMALL", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x28b42698caf46b4b012cf38b6c75867e0762186d&to=0x4200000000000000000000000000000000000006",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x28b42698caf46b4b012cf38b6c75867e0762186d&token1=0x4200000000000000000000000000000000000006&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x28b42698caf46b4b012cf38b6c75867e0762186d&token1=0x4200000000000000000000000000000000000006&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x9269f5199b01b7b7dd38321b85c3f34ee3f28f7f",
     "network": "optimism",
     "zaps": [
@@ -1239,7 +1248,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_SMALL", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x28b42698caf46b4b012cf38b6c75867e0762186d&to=0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x28b42698caf46b4b012cf38b6c75867e0762186d&token1=0xda10009cbd5d07dd0cecc66161fc93d7c9000da1&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x28b42698caf46b4b012cf38b6c75867e0762186d&token1=0xda10009cbd5d07dd0cecc66161fc93d7c9000da1&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xfc233ad094c8c9c245bdea891dfee2d7f9e632c4",
     "network": "optimism",
     "zaps": [
@@ -1269,7 +1278,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_NONE", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40&to=0x68f180fcce6836688e9084f035309e29bf0a2095",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40&token1=0x68f180fcce6836688e9084f035309e29bf0a2095&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40&token1=0x68f180fcce6836688e9084f035309e29bf0a2095&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x6e57b9e54ea043a829584b22182ad22bf446926c",
     "network": "optimism",
     "zaps": [
@@ -1299,7 +1308,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40&to=0x4200000000000000000000000000000000000006",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40&token1=0x4200000000000000000000000000000000000006&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40&token1=0x4200000000000000000000000000000000000006&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xadbb23bcc3c1b9810491897cb0690cf645b858b1",
     "network": "optimism",
     "zaps": [
@@ -1329,7 +1338,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_MICRO", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x1e925de1c68ef83bd98ee3e130ef14a50309c01b&to=0x4200000000000000000000000000000000000006",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x1e925de1c68ef83bd98ee3e130ef14a50309c01b&token1=0x4200000000000000000000000000000000000006&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x1e925de1c68ef83bd98ee3e130ef14a50309c01b&token1=0x4200000000000000000000000000000000000006&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xf3c45b45223df6071a478851b9c17e0630fdf535",
     "network": "optimism",
     "zaps": [
@@ -1407,7 +1416,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x4200000000000000000000000000000000000042&to=0x2e3d870790dc77a83dd1d18184acc7439a53f475",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x4200000000000000000000000000000000000042&token1=0x2e3d870790dc77a83dd1d18184acc7439a53f475&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x4200000000000000000000000000000000000042&token1=0x2e3d870790dc77a83dd1d18184acc7439a53f475&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xe9b168fa9409eaffa07679196c7568317baf80ed",
     "network": "optimism",
     "zaps": [
@@ -1444,7 +1453,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x4200000000000000000000000000000000000042&to=0x6806411765af15bddd26f8f544a34cc40cb9838b",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x4200000000000000000000000000000000000042&token1=0x6806411765af15bddd26f8f544a34cc40cb9838b&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x4200000000000000000000000000000000000042&token1=0x6806411765af15bddd26f8f544a34cc40cb9838b&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x2fe304b407c7fab2a3c10962f14db751468a4f5b",
     "network": "optimism",
     "zaps": [
@@ -1481,7 +1490,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x8c6f28f2f1a3c87f0f938b96d27520d9751ec8d9&to=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x8c6f28f2f1a3c87f0f938b96d27520d9751ec8d9&token1=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x8c6f28f2f1a3c87f0f938b96d27520d9751ec8d9&token1=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x3b375ba61920551217f5944f4f5d8a63989a438e",
     "network": "optimism",
     "zaps": [
@@ -1511,7 +1520,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_MICRO", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x9560e827af36c94d2ac33a39bce1fe78631088db&to=0x4200000000000000000000000000000000000006",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x9560e827af36c94d2ac33a39bce1fe78631088db&token1=0x4200000000000000000000000000000000000006&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x9560e827af36c94d2ac33a39bce1fe78631088db&token1=0x4200000000000000000000000000000000000006&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x58e6433a6903886e440ddf519ecc573c4046a6b2",
     "network": "optimism",
     "zaps": [
@@ -1548,7 +1557,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x73cb180bf0521828d8849bc8cf2b920918e23032&to=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x73cb180bf0521828d8849bc8cf2b920918e23032&token1=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x73cb180bf0521828d8849bc8cf2b920918e23032&token1=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x37e7d30cc180a750c83d68ed0c2511da10694d63",
     "network": "optimism",
     "zaps": [
@@ -1578,7 +1587,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_SMALL", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x217d47011b23bb961eb6d93ca9945b7501a5bb11&to=0x4200000000000000000000000000000000000006",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x217d47011b23bb961eb6d93ca9945b7501a5bb11&token1=0x4200000000000000000000000000000000000006&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x217d47011b23bb961eb6d93ca9945b7501a5bb11&token1=0x4200000000000000000000000000000000000006&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xdff90e4a6c229565f25337b1db9fa12f6d8cb118",
     "network": "optimism",
     "zaps": [
@@ -1644,7 +1653,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_SMALL", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x4200000000000000000000000000000000000006&to=0x5d47baba0d66083c52009271faf3f50dcc01023c",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x4200000000000000000000000000000000000006&token1=0x5d47baba0d66083c52009271faf3f50dcc01023c&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x4200000000000000000000000000000000000006&token1=0x5d47baba0d66083c52009271faf3f50dcc01023c&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xe39120b27e5bfec953524402c2e261763c76519e",
     "network": "optimism",
     "zaps": [
@@ -1681,7 +1690,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x9485aca5bbbe1667ad97c7fe7c4531a624c8b1ed&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x9485aca5bbbe1667ad97c7fe7c4531a624c8b1ed&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x9485aca5bbbe1667ad97c7fe7c4531a624c8b1ed&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x4be2cbe40521279b8fc561e65bb842bf73ec3a80",
     "network": "optimism",
     "zaps": [
@@ -1718,7 +1727,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x73cb180bf0521828d8849bc8cf2b920918e23032&to=0x970d50d09f3a656b43e11b0d45241a84e3a6e011",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x73cb180bf0521828d8849bc8cf2b920918e23032&token1=0x970d50d09f3a656b43e11b0d45241a84e3a6e011&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x73cb180bf0521828d8849bc8cf2b920918e23032&token1=0x970d50d09f3a656b43e11b0d45241a84e3a6e011&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x667002f9dc61ebcba8ee1cbeb2ad04060388f223",
     "network": "optimism",
     "zaps": [
@@ -1755,7 +1764,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x79af5dd14e855823fa3e9ecacdf001d99647d043&to=0x9485aca5bbbe1667ad97c7fe7c4531a624c8b1ed",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x79af5dd14e855823fa3e9ecacdf001d99647d043&token1=0x9485aca5bbbe1667ad97c7fe7c4531a624c8b1ed&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x79af5dd14e855823fa3e9ecacdf001d99647d043&token1=0x9485aca5bbbe1667ad97c7fe7c4531a624c8b1ed&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x3dd9556a521d6e57be480c94da102fedf0429aba",
     "network": "optimism",
     "zaps": [
@@ -1792,7 +1801,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x2e3d870790dc77a83dd1d18184acc7439a53f475&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x2e3d870790dc77a83dd1d18184acc7439a53f475&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x2e3d870790dc77a83dd1d18184acc7439a53f475&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x8542dd4744edea38b8a9306268b08f4d26d38581",
     "network": "optimism",
     "zaps": [
@@ -1828,7 +1837,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x2e3d870790dc77a83dd1d18184acc7439a53f475&to=0xdfa46478f9e5ea86d57387849598dbfb2e964b02",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x2e3d870790dc77a83dd1d18184acc7439a53f475&token1=0xdfa46478f9e5ea86d57387849598dbfb2e964b02&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x2e3d870790dc77a83dd1d18184acc7439a53f475&token1=0xdfa46478f9e5ea86d57387849598dbfb2e964b02&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xc37a0a37664aeb3848f98c5dd5d7ae286a1e9ebd",
     "network": "optimism",
     "zaps": [
@@ -1858,7 +1867,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_SMALL", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x929b939f8524c3be977af57a4a0ad3fb1e374b50&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x929b939f8524c3be977af57a4a0ad3fb1e374b50&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x929b939f8524c3be977af57a4a0ad3fb1e374b50&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x8453cc52f2108ff9d1636b6a108db06ac137b72f",
     "network": "optimism",
     "zaps": [
@@ -1890,7 +1899,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_MICRO", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x61baadcf22d2565b0f471b291c475db5555e0b76&to=0x4200000000000000000000000000000000000006",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x61baadcf22d2565b0f471b291c475db5555e0b76&token1=0x4200000000000000000000000000000000000006&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x61baadcf22d2565b0f471b291c475db5555e0b76&token1=0x4200000000000000000000000000000000000006&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x5da5e8a46d435d619a12086620bc77bf7fb043e5",
     "network": "optimism",
     "zaps": [
@@ -1922,7 +1931,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_SMALL", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x5d47baba0d66083c52009271faf3f50dcc01023c&to=0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x5d47baba0d66083c52009271faf3f50dcc01023c&token1=0xda10009cbd5d07dd0cecc66161fc93d7c9000da1&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x5d47baba0d66083c52009271faf3f50dcc01023c&token1=0xda10009cbd5d07dd0cecc66161fc93d7c9000da1&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xc0a0adf5e3b07e383c2c1533b2f0878a3195c622",
     "network": "optimism",
     "zaps": [
@@ -1961,7 +1970,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0xdb4ea87ff83eb1c80b8976fc47731da6a31d35e5&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xdb4ea87ff83eb1c80b8976fc47731da6a31d35e5&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xdb4ea87ff83eb1c80b8976fc47731da6a31d35e5&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x5e6e17f745ff620e87324b7c6ec672b5743bd0b4",
     "network": "optimism",
     "zaps": [
@@ -1991,7 +2000,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x8700daec35af8ff88c16bdf0418774cb3d7599b4&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x8700daec35af8ff88c16bdf0418774cb3d7599b4&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x8700daec35af8ff88c16bdf0418774cb3d7599b4&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x71d53b5b7141e1ec9a3fc9cc48b4766102d14a4a",
     "network": "optimism",
     "zaps": [
@@ -2021,7 +2030,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_LARGE", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x1f32b1c2345538c0c6f582fcb022739c4a194ebb&to=0xfdb794692724153d1488ccdbe0c56c252596735f",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x1f32b1c2345538c0c6f582fcb022739c4a194ebb&token1=0xfdb794692724153d1488ccdbe0c56c252596735f&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x1f32b1c2345538c0c6f582fcb022739c4a194ebb&token1=0xfdb794692724153d1488ccdbe0c56c252596735f&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xc5c247580a4a6e4d3811c0da6215057aac480bac",
     "network": "optimism",
     "zaps": [
@@ -2051,7 +2060,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_LOW", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819&to=0x4200000000000000000000000000000000000006",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819&token1=0x4200000000000000000000000000000000000006&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819&token1=0x4200000000000000000000000000000000000006&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x6387765ffa609ab9a1da1b16c455548bfed7cbea",
     "network": "optimism",
     "zaps": [
@@ -2081,7 +2090,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_MICRO", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x1db2466d9f5e10d7090e7152b68d62703a2245f0&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x1db2466d9f5e10d7090e7152b68d62703a2245f0&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x1db2466d9f5e10d7090e7152b68d62703a2245f0&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x4e60495550071693bc8bdffc40033d278157eac7",
     "network": "optimism",
     "zaps": [
@@ -2111,7 +2120,7 @@
     "risks": ["COMPLEXITY_LOW", "IL_NONE", "MCAP_LARGE", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0xe405de8f52ba7559f9df3c368500b6e6ae6cee49&to=0x4200000000000000000000000000000000000006",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xe405de8f52ba7559f9df3c368500b6e6ae6cee49&token1=0x4200000000000000000000000000000000000006&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xe405de8f52ba7559f9df3c368500b6e6ae6cee49&token1=0x4200000000000000000000000000000000000006&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x5e5a37445fadeb71f23514ae7d675ffc644e5e5a",
     "network": "optimism",
     "zaps": [
@@ -2147,7 +2156,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0xda10009cbd5d07dd0cecc66161fc93d7c9000da1&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xda10009cbd5d07dd0cecc66161fc93d7c9000da1&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xda10009cbd5d07dd0cecc66161fc93d7c9000da1&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x19715771e30c93915a5bbda134d782b81a820076",
     "network": "optimism",
     "zaps": [
@@ -2183,7 +2192,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x8c6f28f2f1a3c87f0f938b96d27520d9751ec8d9&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x8c6f28f2f1a3c87f0f938b96d27520d9751ec8d9&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x8c6f28f2f1a3c87f0f938b96d27520d9751ec8d9&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x6d5ba400640226e24b50214d2bbb3d4db8e6e15a",
     "network": "optimism",
     "zaps": [
@@ -2213,7 +2222,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x4200000000000000000000000000000000000042&to=0x4200000000000000000000000000000000000006",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x4200000000000000000000000000000000000042&token1=0x4200000000000000000000000000000000000006&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x4200000000000000000000000000000000000042&token1=0x4200000000000000000000000000000000000006&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xd25711edfbf747efce181442cc1d8f5f8fc8a0d3",
     "network": "optimism",
     "zaps": [
@@ -2249,7 +2258,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xf04458f7b21265b80fc340de7ee598e24485c5bb",
     "network": "optimism",
     "zaps": [
@@ -2286,7 +2295,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x8ae125e8653821e851f12a49f7765db9a9ce7384&to=0x2e3d870790dc77a83dd1d18184acc7439a53f475",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x8ae125e8653821e851f12a49f7765db9a9ce7384&token1=0x2e3d870790dc77a83dd1d18184acc7439a53f475&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x8ae125e8653821e851f12a49f7765db9a9ce7384&token1=0x2e3d870790dc77a83dd1d18184acc7439a53f475&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x1f8b46abe1eabf5a60cbbb5fb2e4a6a46fa0b6e6",
     "network": "optimism",
     "zaps": [
@@ -2323,7 +2332,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x73cb180bf0521828d8849bc8cf2b920918e23032&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x73cb180bf0521828d8849bc8cf2b920918e23032&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x73cb180bf0521828d8849bc8cf2b920918e23032&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xd95e98fc33670dc033424e7aa0578d742d00f9c7",
     "network": "optimism",
     "zaps": [
@@ -2359,7 +2368,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819&to=0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819&token1=0xda10009cbd5d07dd0cecc66161fc93d7c9000da1&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819&token1=0xda10009cbd5d07dd0cecc66161fc93d7c9000da1&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x0d0f65c63e379263f7ce2713dd012180681d0dc5",
     "network": "optimism",
     "zaps": [
@@ -2396,7 +2405,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a&to=0x2e3d870790dc77a83dd1d18184acc7439a53f475",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a&token1=0x2e3d870790dc77a83dd1d18184acc7439a53f475&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a&token1=0x2e3d870790dc77a83dd1d18184acc7439a53f475&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xaf03f51de7a0e62bf061f6fc3931cf79166b0a29",
     "network": "optimism",
     "zaps": [
@@ -2433,7 +2442,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x3e29d3a9316dab217754d13b28646b76607c5f04&to=0x6806411765af15bddd26f8f544a34cc40cb9838b",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x3e29d3a9316dab217754d13b28646b76607c5f04&token1=0x6806411765af15bddd26f8f544a34cc40cb9838b&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x3e29d3a9316dab217754d13b28646b76607c5f04&token1=0x6806411765af15bddd26f8f544a34cc40cb9838b&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x1ad06ca54de04dbe9e2817f4c13ecb406dcbeaf0",
     "network": "optimism",
     "zaps": [
@@ -2470,7 +2479,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x73cb180bf0521828d8849bc8cf2b920918e23032&to=0x2e3d870790dc77a83dd1d18184acc7439a53f475",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x73cb180bf0521828d8849bc8cf2b920918e23032&token1=0x2e3d870790dc77a83dd1d18184acc7439a53f475&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x73cb180bf0521828d8849bc8cf2b920918e23032&token1=0x2e3d870790dc77a83dd1d18184acc7439a53f475&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xd330841ef9527e3bd0abc28a230c7ca8dec9423b",
     "network": "optimism",
     "zaps": [
@@ -2500,7 +2509,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_NONE", "MCAP_LARGE", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x9bcef72be871e61ed4fbbc7630889bee758eb81d&to=0x4200000000000000000000000000000000000006",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x9bcef72be871e61ed4fbbc7630889bee758eb81d&token1=0x4200000000000000000000000000000000000006&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x9bcef72be871e61ed4fbbc7630889bee758eb81d&token1=0x4200000000000000000000000000000000000006&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x7e0f65fab1524da9e2e5711d160541cf1199912e",
     "network": "optimism",
     "zaps": [
@@ -2537,7 +2546,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x1f32b1c2345538c0c6f582fcb022739c4a194ebb&to=0x4200000000000000000000000000000000000006",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x1f32b1c2345538c0c6f582fcb022739c4a194ebb&token1=0x4200000000000000000000000000000000000006&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x1f32b1c2345538c0c6f582fcb022739c4a194ebb&token1=0x4200000000000000000000000000000000000006&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x6da98bde0068d10ddd11b468b197ea97d96f96bc",
     "network": "optimism",
     "zaps": [
@@ -2574,7 +2583,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x1f32b1c2345538c0c6f582fcb022739c4a194ebb&to=0x4200000000000000000000000000000000000042",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x1f32b1c2345538c0c6f582fcb022739c4a194ebb&token1=0x4200000000000000000000000000000000000042&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x1f32b1c2345538c0c6f582fcb022739c4a194ebb&token1=0x4200000000000000000000000000000000000042&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x7178f61694ba9109205b8d6f686282307625e62d",
     "network": "optimism",
     "zaps": [
@@ -2611,7 +2620,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x8ae125e8653821e851f12a49f7765db9a9ce7384&to=0xdfa46478f9e5ea86d57387849598dbfb2e964b02",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x8ae125e8653821e851f12a49f7765db9a9ce7384&token1=0xdfa46478f9e5ea86d57387849598dbfb2e964b02&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x8ae125e8653821e851f12a49f7765db9a9ce7384&token1=0xdfa46478f9e5ea86d57387849598dbfb2e964b02&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xbe418771bc91f75c4d2bce1d5e2b7286f50992da",
     "network": "optimism",
     "zaps": [
@@ -2648,7 +2657,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x9560e827af36c94d2ac33a39bce1fe78631088db&to=0x4200000000000000000000000000000000000042",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x9560e827af36c94d2ac33a39bce1fe78631088db&token1=0x4200000000000000000000000000000000000042&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x9560e827af36c94d2ac33a39bce1fe78631088db&token1=0x4200000000000000000000000000000000000042&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xe9581d0f1a628b038fc8b2a7f5a7d904f0e2f937",
     "network": "optimism",
     "zaps": [
@@ -2686,7 +2695,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x4d7959d17b9710be87e3657e69d946914221bb88",
     "network": "optimism",
     "zaps": [
@@ -2724,7 +2733,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x3e29d3a9316dab217754d13b28646b76607c5f04&to=0x4200000000000000000000000000000000000006",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x3e29d3a9316dab217754d13b28646b76607c5f04&token1=0x4200000000000000000000000000000000000006&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x3e29d3a9316dab217754d13b28646b76607c5f04&token1=0x4200000000000000000000000000000000000006&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xa1055762336f92b4b8d2edc032a0ce45ead6280a",
     "network": "optimism",
     "zaps": [
@@ -2763,7 +2772,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x10010078a54396f62c96df8532dc2b4847d47ed3&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x10010078a54396f62c96df8532dc2b4847d47ed3&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x10010078a54396f62c96df8532dc2b4847d47ed3&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x6b95147a8d2c7f480c0cf7288fcf268400ce9970",
     "network": "optimism",
     "zaps": [
@@ -2793,7 +2802,7 @@
     "risks": ["COMPLEXITY_LOW", "IL_HIGH", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x920cf626a271321c151d027030d5d08af699456b&to=0x4200000000000000000000000000000000000006",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x920cf626a271321c151d027030d5d08af699456b&token1=0x4200000000000000000000000000000000000006&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x920cf626a271321c151d027030d5d08af699456b&token1=0x4200000000000000000000000000000000000006&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x8f47041adbef5bf321c9f63a0660326614ab6b60",
     "network": "optimism",
     "zaps": [
@@ -2823,7 +2832,7 @@
     "risks": ["COMPLEXITY_LOW", "IL_HIGH", "MCAP_SMALL", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x217d47011b23bb961eb6d93ca9945b7501a5bb11&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x217d47011b23bb961eb6d93ca9945b7501a5bb11&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x217d47011b23bb961eb6d93ca9945b7501a5bb11&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xe5f28fc43bb40cdf7202ebe406793815b6f07fbd",
     "network": "optimism",
     "zaps": [
@@ -2853,7 +2862,7 @@
     "risks": ["COMPLEXITY_LOW", "IL_HIGH", "MCAP_SMALL", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x50c5725949a6f0c72e6c4a641f24049a917db0cb&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x50c5725949a6f0c72e6c4a641f24049a917db0cb&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x50c5725949a6f0c72e6c4a641f24049a917db0cb&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xdb61f9b480f0a8b817811cfaa89a1c219c355224",
     "network": "optimism",
     "zaps": [
@@ -2883,7 +2892,7 @@
     "risks": ["COMPLEXITY_LOW", "IL_NONE", "MCAP_SMALL", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x340fe1d898eccaad394e2ba0fc1f93d27c7b717a&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x340fe1d898eccaad394e2ba0fc1f93d27c7b717a&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x340fe1d898eccaad394e2ba0fc1f93d27c7b717a&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x77b6d0279c9cef559ef7c32c31d9a5d8acb664fe",
     "network": "optimism",
     "zaps": [
@@ -2913,7 +2922,7 @@
     "risks": ["COMPLEXITY_LOW", "IL_HIGH", "MCAP_LARGE", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x296f55f8fb28e498b858d0bcda06d955b2cb3f97&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x296f55f8fb28e498b858d0bcda06d955b2cb3f97&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x296f55f8fb28e498b858d0bcda06d955b2cb3f97&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x56770b94279539416855fe29ef14b26438b5e421",
     "network": "optimism",
     "zaps": [
@@ -2943,7 +2952,7 @@
     "risks": ["COMPLEXITY_LOW", "IL_HIGH", "MCAP_LARGE", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x4200000000000000000000000000000000000042&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x4200000000000000000000000000000000000042&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x4200000000000000000000000000000000000042&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x0df083de449f75691fc5a36477a6f3284c269108",
     "network": "optimism",
     "zaps": [
@@ -2975,7 +2984,7 @@
     "risks": ["COMPLEXITY_LOW", "IL_NONE", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x73cb180bf0521828d8849bc8cf2b920918e23032&to=0x8ae125e8653821e851f12a49f7765db9a9ce7384",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x73cb180bf0521828d8849bc8cf2b920918e23032&token1=0x8ae125e8653821e851f12a49f7765db9a9ce7384&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x73cb180bf0521828d8849bc8cf2b920918e23032&token1=0x8ae125e8653821e851f12a49f7765db9a9ce7384&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x0b28c2e41058edc7d66c516c617b664ea86eec5d",
     "network": "optimism",
     "zaps": [
@@ -3011,7 +3020,7 @@
     ],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819&to=0x94b008aa00579c1307b0ef2c499ad98a8ce58e58",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819&token1=0x94b008aa00579c1307b0ef2c499ad98a8ce58e58&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xc40f949f8a4e094d1b49a23ea9241d289b7b2819&token1=0x94b008aa00579c1307b0ef2c499ad98a8ce58e58&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xe8b8bff1e415258eb3d5fa8deee9c38406e609cd",
     "network": "optimism",
     "zaps": [
@@ -3041,7 +3050,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_NONE", "MCAP_SMALL", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0xdfa46478f9e5ea86d57387849598dbfb2e964b02&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xdfa46478f9e5ea86d57387849598dbfb2e964b02&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xdfa46478f9e5ea86d57387849598dbfb2e964b02&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xe54e4020d1c3afdb312095d90054103e68fe34b0",
     "network": "optimism",
     "zaps": [
@@ -3071,7 +3080,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_NONE", "MCAP_SMALL", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x8ae125e8653821e851f12a49f7765db9a9ce7384&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x8ae125e8653821e851f12a49f7765db9a9ce7384&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x8ae125e8653821e851f12a49f7765db9a9ce7384&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xb720fbc32d60bb6dcc955be86b98d8fd3c4ba645",
     "network": "optimism",
     "zaps": [
@@ -3101,7 +3110,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_LARGE", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x4200000000000000000000000000000000000006&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x4200000000000000000000000000000000000006&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x4200000000000000000000000000000000000006&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x0493bf8b6dbb159ce2db2e0e8403e753abd1235b",
     "network": "optimism",
     "zaps": [
@@ -3131,7 +3140,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_SMALL", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x9560e827af36c94d2ac33a39bce1fe78631088db&to=0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x9560e827af36c94d2ac33a39bce1fe78631088db&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x9560e827af36c94d2ac33a39bce1fe78631088db&token1=0x7f5c764cbc14f9669b88837ca1490cca17c31607&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x8134a2fdc127549480865fb8e5a9e8a8a95a54c5",
     "network": "optimism",
     "zaps": [
@@ -3191,7 +3200,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x4e720dd3ac5cfe1e1fbde4935f386bb1c66f4642&to=0x4200000000000000000000000000000000000006",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x4e720dd3ac5cfe1e1fbde4935f386bb1c66f4642&token1=0x4200000000000000000000000000000000000006&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x4e720dd3ac5cfe1e1fbde4935f386bb1c66f4642&token1=0x4200000000000000000000000000000000000006&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x1cdfae29a66b39c30eb2b090a2dbba562026e9ff",
     "network": "optimism",
     "zaps": [
@@ -3223,7 +3232,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x4e720dd3ac5cfe1e1fbde4935f386bb1c66f4642&to=0x4200000000000000000000000000000000000042",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x4e720dd3ac5cfe1e1fbde4935f386bb1c66f4642&token1=0x4200000000000000000000000000000000000042&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x4e720dd3ac5cfe1e1fbde4935f386bb1c66f4642&token1=0x4200000000000000000000000000000000000042&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xe0a1467a9d86d9f433496c48c6831c0142464ce6",
     "network": "optimism",
     "zaps": [
@@ -3253,7 +3262,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_NONE", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x6806411765af15bddd26f8f544a34cc40cb9838b&to=0x4200000000000000000000000000000000000006",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x6806411765af15bddd26f8f544a34cc40cb9838b&token1=0x4200000000000000000000000000000000000006&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x6806411765af15bddd26f8f544a34cc40cb9838b&token1=0x4200000000000000000000000000000000000006&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x3f42dc59dc4df5cd607163bc620168f7ff7ab970",
     "network": "optimism",
     "zaps": [
@@ -3283,7 +3292,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_NONE", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x484c2d6e3cdd945a8b2df735e079178c1036578c&to=0x6806411765af15bddd26f8f544a34cc40cb9838b",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x484c2d6e3cdd945a8b2df735e079178c1036578c&token1=0x6806411765af15bddd26f8f544a34cc40cb9838b&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x484c2d6e3cdd945a8b2df735e079178c1036578c&token1=0x6806411765af15bddd26f8f544a34cc40cb9838b&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xff5318f81dd791e92d51b8a54fa3538832d2890d",
     "network": "optimism",
     "zaps": [
@@ -3313,7 +3322,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_NONE", "MCAP_LARGE", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x7f5c764cbc14f9669b88837ca1490cca17c31607&to=0x94b008aa00579c1307b0ef2c499ad98a8ce58e58",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x7f5c764cbc14f9669b88837ca1490cca17c31607&token1=0x94b008aa00579c1307b0ef2c499ad98a8ce58e58&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x7f5c764cbc14f9669b88837ca1490cca17c31607&token1=0x94b008aa00579c1307b0ef2c499ad98a8ce58e58&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0x2b47c794c3789f499d8a54ec12f949eecce8ba16",
     "network": "optimism",
     "zaps": [
@@ -3343,7 +3352,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_NONE", "MCAP_SMALL", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a&to=0xdfa46478f9e5ea86d57387849598dbfb2e964b02",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a&token1=0xdfa46478f9e5ea86d57387849598dbfb2e964b02&stable=true",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a&token1=0xdfa46478f9e5ea86d57387849598dbfb2e964b02&type=0",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xfa09479d72e2b3f8b6df63399772237ad6658d76",
     "network": "optimism",
     "zaps": [
@@ -3373,7 +3382,7 @@
     "risks": ["COMPLEXITY_LOW", "BATTLE_TESTED", "IL_HIGH", "MCAP_SMALL", "CONTRACTS_VERIFIED"],
     "strategyTypeId": "lp",
     "buyTokenUrl": "https://velodrome.finance/swap?from=0x9485aca5bbbe1667ad97c7fe7c4531a624c8b1ed&to=0x4200000000000000000000000000000000000042",
-    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x9485aca5bbbe1667ad97c7fe7c4531a624c8b1ed&token1=0x4200000000000000000000000000000000000042&stable=false",
+    "addLiquidityUrl": "https://velodrome.finance/deposit?token0=0x9485aca5bbbe1667ad97c7fe7c4531a624c8b1ed&token1=0x4200000000000000000000000000000000000042&type=-1",
     "removeLiquidityUrl": "https://velodrome.finance/withdraw?pool=0xefe139aa71b674168f5823360a824b3714f2718d",
     "network": "optimism",
     "zaps": [


### PR DESCRIPTION
Velodrome V2 URL attributes have changed from `stable=true` to `type=0` and `stable=false` to `type=-1`. This is important to fix because the current vault Add Liquidity buttons can direct someone to the wrong type, sending them to a stable pair when it is supposed to be volatile.

Additionally:
- Added missing `buyTokenUrl` values
- Fixed incomplete `removeLiquidityUrl` values
- Added `V2` where missing for a few vault names
- Removed legacy app subdomain for partner website