### PR TITLE
app version check

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { Redirects } from './components/Redirects';
 import { Stepper } from './components/Stepper';
 import { Layout } from './components/Layout';
 import { AddTokenToWallet } from './components/AddTokenToWallet';
+import { AppVersionCheck } from './components/AppVersionCheck';
 
 const Home = lazy(() => import(`./features/home`));
 const Vault = lazy(() => import(`./features/vault`));
@@ -72,6 +73,7 @@ export const App = () => {
             </Layout>
           </Router>
         </HelmetProvider>
+        <AppVersionCheck />
       </ThemeProvider>
     </Suspense>
   );

--- a/src/components/AppVersionCheck/AppVersionCheck.tsx
+++ b/src/components/AppVersionCheck/AppVersionCheck.tsx
@@ -1,0 +1,89 @@
+import { memo, useCallback, useEffect, useMemo } from 'react';
+import { makeStyles } from '@material-ui/core';
+import { styles } from './styles';
+import { useAppDispatch, useAppSelector } from '../../store';
+import { type BuildVersion, setUpdateAvailable } from '../../features/data/reducers/ui-version';
+import { selectAppVersionInfo } from '../../features/data/selectors/version';
+import { useTranslation } from 'react-i18next';
+import { Button } from '../Button';
+import { featureFlag_simUpdate } from '../../features/data/utils/feature-flags';
+
+const useStyles = makeStyles(styles);
+
+export const AppVersionCheck = memo(function AppVersionCheck() {
+  const { t } = useTranslation();
+  const classes = useStyles();
+  const dispatch = useAppDispatch();
+  const app = useAppSelector(selectAppVersionInfo);
+  const message = useMemo(() => {
+    if (app.updateAvailable) {
+      const key = app.reloadFailed ? 'Update-Available-Failed' : 'Update-Available';
+      return t(key, {
+        currentDate: new Date(app.currentVersion.timestamp).toLocaleString(),
+        currentVersion: app.currentVersion.git || app.currentVersion.content,
+        newDate: new Date(app.newVersion.timestamp).toLocaleString(),
+        newVersion: app.newVersion.git || app.newVersion.content,
+      });
+    }
+    return undefined;
+  }, [t, app]);
+  const handleReload = useCallback(() => {
+    if (app.updateAvailable) {
+      const url = new URL(window.location.href);
+      url.searchParams.set('update', app.newVersion.timestamp.toString());
+      window.location.href = url.toString();
+    } else {
+      window.location.reload();
+    }
+  }, [app]);
+
+  useEffect(() => {
+    if (window) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__beefyHandleNewVersion = async (
+        currentVersion: BuildVersion,
+        newVersion: BuildVersion,
+        reloadFailed: boolean
+      ) => {
+        dispatch(setUpdateAvailable({ currentVersion, newVersion, reloadFailed }));
+        return true;
+      };
+
+      if (featureFlag_simUpdate()) {
+        const query = new URLSearchParams(window.location.search);
+        dispatch(
+          setUpdateAvailable({
+            currentVersion: {
+              content: '2b9ed1eb45c03272e67691eb5f69ef6d',
+              timestamp: 1717012504,
+              git: 'f55adb5319d150c07017f7480e8d388e530f92e2',
+            },
+            newVersion: {
+              content: '2b9ed1eb45c03272e67691eb5f69ef6f',
+              timestamp: 1717512504,
+              git: 'f55adb5319d150c07017f7480e8d388e530f92e3',
+            },
+            reloadFailed: query.get('update') === '1717512504',
+          })
+        );
+      }
+    }
+  }, [dispatch]);
+
+  if (!app.updateAvailable) {
+    return null;
+  }
+
+  return (
+    <div className={classes.positioner}>
+      <div className={classes.alert}>
+        <div className={classes.message}>{message}</div>
+        <div className={classes.action}>
+          <Button onClick={handleReload} size={'sm'} variant={'success'} className={classes.button}>
+            {t('Update-Reload')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/src/components/AppVersionCheck/AppVersionCheck.tsx
+++ b/src/components/AppVersionCheck/AppVersionCheck.tsx
@@ -88,11 +88,18 @@ export const AppVersionCheck = memo(function AppVersionCheck() {
     <div className={classes.positioner}>
       <div className={classes.alert}>
         <div className={classes.message}>{message}</div>
-        <div className={classes.action}>
-          <Button onClick={handleReload} size={'sm'} variant={'success'} className={classes.button}>
-            {t('Update-Reload')}
-          </Button>
-        </div>
+        {!app.reloadFailed ? (
+          <div className={classes.action}>
+            <Button
+              onClick={handleReload}
+              size={'sm'}
+              variant={'success'}
+              className={classes.button}
+            >
+              {t('Update-Reload')}
+            </Button>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/src/components/AppVersionCheck/AppVersionCheck.tsx
+++ b/src/components/AppVersionCheck/AppVersionCheck.tsx
@@ -10,6 +10,17 @@ import { featureFlag_simUpdate } from '../../features/data/utils/feature-flags';
 
 const useStyles = makeStyles(styles);
 
+declare global {
+  interface Window {
+    __beefyHandleNewVersion?: (
+      currentVersion: BuildVersion,
+      newVersion: BuildVersion,
+      reloadFailed: boolean,
+      newVersionMessage: string
+    ) => Promise<boolean>;
+  }
+}
+
 export const AppVersionCheck = memo(function AppVersionCheck() {
   const { t } = useTranslation();
   const classes = useStyles();
@@ -39,8 +50,7 @@ export const AppVersionCheck = memo(function AppVersionCheck() {
 
   useEffect(() => {
     if (window) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).__beefyHandleNewVersion = async (
+      window.__beefyHandleNewVersion = async (
         currentVersion: BuildVersion,
         newVersion: BuildVersion,
         reloadFailed: boolean

--- a/src/components/AppVersionCheck/index.tsx
+++ b/src/components/AppVersionCheck/index.tsx
@@ -1,0 +1,1 @@
+export * from './AppVersionCheck';

--- a/src/components/AppVersionCheck/styles.tsx
+++ b/src/components/AppVersionCheck/styles.tsx
@@ -1,0 +1,47 @@
+import type { Theme } from '@material-ui/core';
+
+export const styles = (theme: Theme) => ({
+  positioner: {
+    position: 'fixed' as const,
+    bottom: 0,
+    left: 0,
+    padding: '0 32px 32px 32px',
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 100,
+    pointerEvents: 'none' as const,
+    [theme.breakpoints.down('xs')]: {
+      padding: '0 16px 16px 16px',
+    },
+  },
+  alert: {
+    ...theme.typography['body-lg'],
+    pointerEvents: 'auto' as const,
+    flex: '0 1 auto',
+    display: 'flex',
+    gap: '16px',
+    alignItems: 'center',
+    borderRadius: '8px',
+    padding: '16px',
+    backgroundColor: theme.palette.background.contentDark,
+    [theme.breakpoints.down('xs')]: {
+      flexDirection: 'column' as const,
+    },
+  },
+  message: {
+    flex: '1 1 auto',
+  },
+  action: {
+    flex: '0 0 auto',
+    [theme.breakpoints.down('xs')]: {
+      width: '100%',
+    },
+  },
+  button: {
+    [theme.breakpoints.down('xs')]: {
+      width: '100%',
+    },
+  },
+});

--- a/src/features/data/reducers/index.tsx
+++ b/src/features/data/reducers/index.tsx
@@ -39,6 +39,7 @@ import { tooltipsSlice } from './tooltips';
 import { addToWalletSlice } from './add-to-wallet';
 import { articlesSlice } from './articles';
 import { rewardsReducer } from './wallet/rewards';
+import { versionReducer } from './ui-version';
 
 const entitiesReducer = combineReducers<BeefyState['entities']>({
   chains: chainsSlice.reducer,
@@ -96,6 +97,7 @@ const uiReducer = combineReducers<BeefyState['ui']>({
   treasury: treasurySlice.reducer,
   tooltips: tooltipsSlice.reducer,
   addToWallet: addToWalletSlice.reducer,
+  version: versionReducer,
 });
 
 export const rootReducer = combineReducers<BeefyState>({

--- a/src/features/data/reducers/ui-version.ts
+++ b/src/features/data/reducers/ui-version.ts
@@ -1,0 +1,44 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+export type BuildVersion = {
+  /** git commit hash of build */
+  git?: string;
+  /** unix timestamp of build */
+  timestamp: number;
+  /** manifest content hash of build */
+  content: string;
+};
+
+export type NewVersionAvailable = {
+  currentVersion: BuildVersion;
+  newVersion: BuildVersion;
+  reloadFailed: boolean;
+};
+
+export type VersionState =
+  | {
+      updateAvailable: false;
+    }
+  | ({
+      updateAvailable: true;
+    } & NewVersionAvailable);
+
+const initialState: VersionState = {
+  updateAvailable: false,
+} as VersionState;
+
+export const versionSlice = createSlice({
+  name: 'ui-version',
+  initialState,
+  reducers: {
+    setUpdateAvailable(_, action: PayloadAction<NewVersionAvailable>) {
+      return {
+        updateAvailable: true,
+        ...action.payload,
+      };
+    },
+  },
+});
+
+export const { setUpdateAvailable } = versionSlice.actions;
+export const versionReducer = versionSlice.reducer;

--- a/src/features/data/selectors/version.ts
+++ b/src/features/data/selectors/version.ts
@@ -1,0 +1,3 @@
+import type { BeefyState } from '../../../redux-types';
+
+export const selectAppVersionInfo = (state: BeefyState) => state.ui.version;

--- a/src/features/data/utils/feature-flags.ts
+++ b/src/features/data/utils/feature-flags.ts
@@ -246,3 +246,8 @@ export function featureFlag_disableKyber(): boolean {
   const params = getSearchParams();
   return params.has('__disable_kyber');
 }
+
+export function featureFlag_simUpdate(): boolean {
+  const params = getSearchParams();
+  return params.has('__sim_update');
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,6 @@ import { PersistGate } from 'redux-persist/integration/react';
 import { Provider } from 'react-redux';
 import { App } from './App';
 import { persistor, store } from './store';
-
 import './i18n';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -705,5 +705,8 @@
   "Rewards-Title": "CLM Incentives",
   "Rewards-Description": "This position is receiving rewards through Merkl in addition to trading fees. These rewards are distributed several times per day and are claimed with all other available rewards from Merkl.",
   "Rewards-Claim": "Claim All",
-  "Rewards-OtherRewards": "Other Rewards ({{value}})"
+  "Rewards-OtherRewards": "Other Rewards ({{value}})",
+  "Update-Available": "Reload to get the latest version of Beefy",
+  "Update-Available-Failed": "A new version of Beefy is available. Please clear your browser cache and reload the page to get the latest version.",
+  "Update-Reload": "Reload"
 }

--- a/src/redux-types.ts
+++ b/src/redux-types.ts
@@ -36,6 +36,7 @@ import type { TooltipsState } from './features/data/reducers/tooltips';
 import type { AddToWalletState } from './features/data/reducers/add-to-wallet';
 import type { ArticlesState } from './features/data/reducers/articles';
 import type { RewardsState } from './features/data/reducers/wallet/rewards';
+import type { VersionState } from './features/data/reducers/ui-version';
 
 export interface BeefyState {
   entities: {
@@ -80,6 +81,7 @@ export interface BeefyState {
     savedVaults: SavedVaultsState;
     tooltips: TooltipsState;
     addToWallet: AddToWalletState;
+    version: VersionState;
   };
 }
 

--- a/version-checker.ts
+++ b/version-checker.ts
@@ -1,0 +1,108 @@
+type BuildVersion = {
+  /** git commit hash of build */
+  git?: string;
+  /** unix timestamp of build */
+  timestamp: number;
+  /** manifest content hash of build */
+  content: string;
+};
+
+type HandleNewVersionFn = (
+  currentVersion: BuildVersion,
+  newVersion: BuildVersion,
+  reloadFailed: boolean,
+  newVersionMessage: string
+) => Promise<boolean>;
+
+type WindowType = Window & {
+  __beefyHandleNewVersion?: HandleNewVersionFn;
+};
+
+(function (localVersion) {
+  const handleNewVersionFallback: HandleNewVersionFn = async (
+    _currentVersion: BuildVersion,
+    newVersion: BuildVersion,
+    reloadFailed: boolean,
+    newVersionMessage: string
+  ) => {
+    console.info(newVersionMessage);
+    if (reloadFailed) {
+      alert(
+        `Your browser failed to fetch the latest version when reloading. Please clear your cache and try again.`
+      );
+      return false;
+    }
+
+    if (confirm(`${newVersionMessage}\n\nReload to update?`)) {
+      const url = new URL(window.location.href);
+      url.searchParams.set('update', newVersion.timestamp.toString());
+      window.location.href = url.toString();
+      return true;
+    }
+
+    console.warn(`User declined to reload.`);
+    return false;
+  };
+  const waitForHandler = (() => {
+    let timeWaited = 0;
+    return async () => {
+      const typedWindow = window as WindowType;
+      while (!typedWindow.__beefyHandleNewVersion && ++timeWaited < 10) {
+        await new Promise(resolve => setTimeout(resolve, 1_000));
+      }
+      return typedWindow.__beefyHandleNewVersion || handleNewVersionFallback;
+    };
+  })();
+  const handleNewVersion = async newVersion => {
+    const currentDate = new Date(localVersion.timestamp * 1000).toLocaleString();
+    const newDate = new Date(newVersion.timestamp * 1000).toLocaleString();
+    const newVersionMessage = `A new version of the app is available.\n\nYou have version ${
+      localVersion.git || localVersion.content
+    } from ${currentDate}.\nThe latest version is ${
+      newVersion.git || newVersion.content
+    } from ${newDate}.`;
+    console.info(newVersionMessage);
+
+    const query = new URLSearchParams(window.location.search);
+    const reloadFailed = query.get('update') === newVersion.timestamp.toString();
+
+    const handler = await waitForHandler();
+    return await handler(localVersion, newVersion, reloadFailed, newVersionMessage);
+  };
+  const checkForUpdate = async () => {
+    try {
+      const response = await fetch(`/version.json`, { cache: 'no-store' });
+      const latestVersion = await response.json();
+      const isNewer = latestVersion.timestamp > localVersion.timestamp;
+      const isContentDifferent = latestVersion.content !== localVersion.content;
+      const isGitDifferent =
+        localVersion.git !== undefined &&
+        latestVersion.git !== undefined &&
+        latestVersion.git !== localVersion.git;
+      const isDifferent = isContentDifferent || isGitDifferent;
+      if (isNewer && isDifferent) {
+        return await handleNewVersion(latestVersion);
+      }
+    } catch (error) {
+      console.error('Failed to check for updates:', error);
+    }
+    return true;
+  };
+  const tryCheckForUpdate = () => {
+    checkForUpdate()
+      .then(continueMonitoring => {
+        if (continueMonitoring) {
+          scheduleCheckForUpdate();
+        }
+      })
+      .catch(e => {
+        console.error(e);
+        scheduleCheckForUpdate();
+      });
+  };
+  const scheduleCheckForUpdate = () => {
+    setTimeout(tryCheckForUpdate, 1000 * 60);
+  };
+
+  setTimeout(tryCheckForUpdate, 1000 * 5);
+})(JSON.parse('$$VERSION_PLACEHOLDER$$'));

--- a/version-plugin.ts
+++ b/version-plugin.ts
@@ -1,0 +1,84 @@
+import type { Plugin } from 'vite';
+import { exec } from 'node:child_process';
+import type { OutputBundle } from 'rollup';
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { transform } from 'esbuild';
+
+export default function (): Plugin {
+  type BuildVersion = {
+    content: string;
+    timestamp: number;
+    git: string | undefined;
+  };
+
+  async function getGitHashOrUndefined(): Promise<string | undefined> {
+    return new Promise(resolve => {
+      exec('git rev-parse HEAD', (error, stdout) => {
+        if (error) {
+          console.warn('Failed to get git hash, version.git will be undefined');
+          resolve(undefined);
+        } else {
+          const output = stdout.toString()?.replace('\n', '');
+          resolve(output || undefined);
+        }
+      });
+    });
+  }
+
+  function getContentHash(bundle: OutputBundle): string {
+    return createHash('md5')
+      .update(JSON.stringify(Object.keys(bundle).sort()))
+      .digest('hex');
+  }
+
+  function getCloudflareHeaders(version: BuildVersion) {
+    return `/*
+  X-Git-Commit: ${version.git || 'undefined'}
+  X-Build-Timestamp: ${version.timestamp}
+  X-Content-Hash: ${version.content}
+`;
+  }
+
+  async function getCheckerScript(version: BuildVersion) {
+    const code = await readFile(path.resolve(__dirname, 'version-checker.ts'), 'utf-8');
+    const codeWithVersion = code.replace(
+      "'$$VERSION_PLACEHOLDER$$'",
+      JSON.stringify(JSON.stringify(version))
+    );
+    const minified = await transform(codeWithVersion, { minify: true, loader: 'ts' });
+
+    return `<script>${minified.code}</script>`;
+  }
+
+  return {
+    name: 'version-plugin',
+    enforce: 'post',
+    apply: 'build',
+    async generateBundle(options, bundle) {
+      const content = getContentHash(bundle);
+      const timestamp = Math.floor(Date.now() / 1000);
+      const git = await getGitHashOrUndefined();
+      const version = { content, timestamp, git };
+
+      this.emitFile({
+        fileName: 'version.json',
+        type: 'asset',
+        source: JSON.stringify(version),
+      });
+
+      this.emitFile({
+        fileName: '_headers',
+        type: 'asset',
+        source: getCloudflareHeaders(version),
+      });
+
+      const index = bundle['index.html'];
+      if (index && index.type === 'asset' && typeof index.source === 'string') {
+        const checkerScript = await getCheckerScript(version);
+        index.source = index.source.replace('</body>', `${checkerScript}</body>`);
+      }
+    },
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,14 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type PluginOption } from 'vite';
 import { NodeGlobalsPolyfillPlugin } from '@esbuild-plugins/node-globals-polyfill';
 import RollupNodePolyFillPlugin from 'rollup-plugin-polyfill-node';
 import react from '@vitejs/plugin-react';
 import svgrPlugin from 'vite-plugin-svgr';
 import eslint from 'vite-plugin-eslint';
 import { visualizer } from 'rollup-plugin-visualizer';
-import * as path from 'path';
+import * as path from 'node:path';
+import versionPlugin from './version-plugin';
 
-const optionalPlugins = [];
+const optionalPlugins: PluginOption[] = [];
 
 if (process.env.NODE_ENV === 'development') {
   optionalPlugins.push(eslint());
@@ -36,6 +37,7 @@ export default defineConfig({
       ...svgrPlugin(),
       enforce: 'post',
     },
+    versionPlugin(),
     ...optionalPlugins,
   ],
   optimizeDeps: {


### PR DESCRIPTION
If new version of app is available user will see the following message. Checks for new version on load and every 60s there after.
![image](https://github.com/beefyfinance/beefy-v2/assets/55021052/b511ee86-383a-41d7-8025-a84cd65a8643)
Test: https://bafybeigc4i5c4wdys7yobrqzgxsynm2grbykqazrvczpalmkr6rkfaxnua.on.fleek.co/?__sim_update#/

Clicking reload will reload the page, however this may not bypass the cache in some browsers, if its detected that the user is still on the same (old) version, a different message is displayed.
![image](https://github.com/beefyfinance/beefy-v2/assets/55021052/ea36057d-45cd-417a-afca-9879a9115fb5)
Test: https://bafybeigc4i5c4wdys7yobrqzgxsynm2grbykqazrvczpalmkr6rkfaxnua.on.fleek.co/?__sim_update=&update=1717512504#/

To achieve this, on build a `version.json` file is generated, which the app periodically requests using fetch's `no-store` to bypass the browser cache.
```json
{
  "content": "21fb1670032b1a1748e44e6d46c2c320",
  "timestamp": 1717521235,
  "git": "efab81043f37cf76a8099dca097f9006aca7908f"
}
```
`content`: is an md5 hash of all the build asset filenames output from vite build (which themselves have content hashes)
`timestamp`: is unix timestamp of when the build happened
`git`: is commit hash (`git rev-parse HEAD`) that build was created from (if built from a git directory)
Test: https://bafybeibgpumvksjf7uj7rauttsgajqy5glwh2rhstpdg5dhql5p3tegdbe.on.fleek.co/version.json
an update is marked as available if either `content` or `git` hash has changed AND the `timestamp` is newer