### PR TITLE
CLM PnL fix

### DIFF
--- a/src/helpers/pnl.ts
+++ b/src/helpers/pnl.ts
@@ -198,8 +198,6 @@ export class ClmPnl {
     }
 
     let remainingSharesToSell = transaction.shares.negated();
-    const remainingToken0SharesToSell = transaction.token0Amount.negated();
-    const remainingToken1SharesToSell = transaction.token1Amount.negated();
     let trxPnl = BIG_ZERO;
     let trxPnlUsd = BIG_ZERO;
     let idx = 0;
@@ -216,8 +214,8 @@ export class ClmPnl {
       const entryPrice = token0AmountToUsd.plus(token1AmountToUsd);
 
       const sharesToSell = BigNumber.min(remainingSharesToSell, remainingShares);
-      const token0SharesToSell = BigNumber.min(remainingToken0SharesToSell, token0Amount);
-      const token1SharesToSell = BigNumber.min(remainingToken1SharesToSell, token1Amount);
+      const token0ToSell = sharesToSell.times(token0Amount).dividedBy(remainingShares);
+      const token1ToSell = sharesToSell.times(token1Amount).dividedBy(remainingShares);
 
       const entryShareAmount = remainingShares;
       const entryUsdAmount = entryShareAmount.times(entryPrice);
@@ -230,8 +228,8 @@ export class ClmPnl {
 
       remainingSharesToSell = remainingSharesToSell.minus(sharesToSell);
       this.state.sharesFifo[idx].remainingShares = remainingShares.minus(sharesToSell);
-      this.state.sharesFifo[idx].token0Amount = token0Amount.minus(token0SharesToSell);
-      this.state.sharesFifo[idx].token1Amount = token1Amount.minus(token1SharesToSell);
+      this.state.sharesFifo[idx].token0Amount = token0Amount.minus(token0ToSell);
+      this.state.sharesFifo[idx].token1Amount = token1Amount.minus(token1ToSell);
 
       if (remainingSharesToSell.isZero()) {
         break;


### PR DESCRIPTION
Substract underlying tokens in same ratio as og transaction had done it when calculating remaining shares/tokens

Removes bug where underlying amounts could be subtracted from multiple deposit txs (lowering at deposit values)