### PR TITLE
CLM deposit token key

### DIFF
--- a/src/features/data/reducers/vaults.ts
+++ b/src/features/data/reducers/vaults.ts
@@ -288,7 +288,9 @@ function addVaultToState(
       name: apiVault.name,
       type: 'cowcentrated',
       version: apiVault.version || 1,
-      depositTokenAddress: apiVault.tokenAddress ?? 'native',
+      depositTokenAddress: apiVault.tokenAddress
+        ? apiVault.tokenAddress + '-' + apiVault.id
+        : 'native',
       depositTokenAddresses: apiVault.depositTokenAddresses || [],
       zaps: apiVault.zaps || [],
       earnContractAddress: apiVault.earnContractAddress,

--- a/src/features/data/selectors/tokens.ts
+++ b/src/features/data/selectors/tokens.ts
@@ -6,7 +6,7 @@ import { isTokenErc20, isTokenNative } from '../entities/token';
 import { selectAllChainIds, selectChainById } from './chains';
 import { BIG_ZERO } from '../../../helpers/big-number';
 import { selectIsAddressBookLoaded, selectIsGlobalDataAvailable } from './data-loader';
-import { isCowcentratedVault, isGovVault, type VaultEntity } from '../entities/vault';
+import { isGovVault, type VaultEntity } from '../entities/vault';
 import { createCachedSelector } from 're-reselect';
 import { selectCowcentratedVaultById, selectVaultById } from './vaults';
 import type { ApiTimeBucket } from '../apis/beefy/beefy-data-api-types';

--- a/src/features/data/selectors/tokens.ts
+++ b/src/features/data/selectors/tokens.ts
@@ -243,11 +243,7 @@ export const selectLpBreakdownByOracleId = (state: BeefyState, oracleId: TokenEn
   state.entities.tokens.breakdown.byOracleId[oracleId];
 
 export const selectLpBreakdownForVault = (state: BeefyState, vault: VaultEntity) => {
-  if (isCowcentratedVault(vault)) {
-    return selectLpBreakdownByOracleId(state, vault.id);
-  } else {
-    return selectLpBreakdownByTokenAddress(state, vault.chainId, vault.depositTokenAddress);
-  }
+  return selectLpBreakdownByTokenAddress(state, vault.chainId, vault.depositTokenAddress);
 };
 
 export const selectLpBreakdownByTokenAddress = (

--- a/src/features/data/utils/config-hacks.ts
+++ b/src/features/data/utils/config-hacks.ts
@@ -46,7 +46,10 @@ export function getDepositTokenFromLegacyVaultConfig(chain: ChainEntity, apiVaul
       id: apiVault.token,
       chainId: chain.id,
       oracleId: apiVault.oracleId,
-      address: apiVault.tokenAddress,
+      address:
+        apiVault.type === 'cowcentrated'
+          ? apiVault.tokenAddress + '-' + apiVault.id
+          : apiVault.tokenAddress,
       decimals: apiVault.tokenDecimals,
       symbol: apiVault.token,
       providerId: apiVault.tokenProviderId,


### PR DESCRIPTION
change the state key for clm depositTokenAddresses to be the join of address+vaultId to avoid losing data when a pool has multiple clms