### PR TITLE
fix zappable CLM vaults not included by the "Zappable vaults" filter

### DIFF
--- a/src/features/data/actions/zap.ts
+++ b/src/features/data/actions/zap.ts
@@ -3,7 +3,10 @@ import type { BeefyState } from '../../../redux-types';
 import { getBeefyApi, getConfigApi, getTransactApi } from '../apis/instances';
 import type { AmmConfig, SwapAggregatorConfig, ZapConfig } from '../apis/config-types';
 import { ZERO_ADDRESS } from '../../../helpers/addresses';
-import { selectAllStandardVaultsByChainId } from '../selectors/vaults';
+import {
+  selectAllStandardVaultsByChainId,
+  selectAllCowcentratedVaultsByChainId,
+} from '../selectors/vaults';
 import { isFulfilledResult } from '../../../helpers/promises';
 import type { VaultEntity } from '../entities/vault';
 import type { ZapAggregatorTokenSupportResponse } from '../apis/beefy/beefy-api';
@@ -53,7 +56,10 @@ export const calculateZapAvailabilityAction = createAsyncThunk<
   const state = getState();
   const chainIds = keys(state.entities.zaps.zaps.byChainId);
   const vaults = chainIds
-    .flatMap(chainId => selectAllStandardVaultsByChainId(state, chainId))
+    .flatMap(chainId => [
+      ...selectAllStandardVaultsByChainId(state, chainId),
+      ...selectAllCowcentratedVaultsByChainId(state, chainId),
+    ])
     .filter(v => v.zaps?.length > 0);
   const api = await getTransactApi();
   const hasZap = await Promise.allSettled(vaults.map(v => api.fetchVaultHasZap(v.id, getState)));

--- a/src/features/data/selectors/vaults.ts
+++ b/src/features/data/selectors/vaults.ts
@@ -167,6 +167,13 @@ export const selectAllStandardVaultsByChainId = createSelector(
   (byIds, vaultIds): VaultStandard[] => vaultIds.map(id => byIds[id]).filter(isStandardVault)
 );
 
+export const selectAllCowcentratedVaultsByChainId = createSelector(
+  (state: BeefyState) => state.entities.vaults.byId,
+  selectVaultIdsByChainId,
+  (byIds, vaultIds): VaultCowcentrated[] =>
+    vaultIds.map(id => byIds[id]).filter(isCowcentratedVault)
+);
+
 export const selectNonGovVaultIdsByDepositTokenAddress = createCachedSelector(
   (state: BeefyState, chainId: ChainEntity['id'], _tokenAddress: TokenEntity['address']) => chainId,
   (state: BeefyState, chainId: ChainEntity['id'], tokenAddress: TokenEntity['address']) =>


### PR DESCRIPTION
In the Home page, when I select both "CLM" and "Zappable vaults" filters, the zappable CLM vaults are not shown on the vaults list. Not sure if it was intended behavior, I made a possible fix in this pull request. I'm still learning to get more familiar with the code, please let me know if there's any suggestions. Thanks! 