### PR TITLE
Add 2 Aerodrome CLM vaults on Base(need help with subOracle data missing)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@web3-onboard/walletconnect": "^2.6.1",
     "axios": "^0.21.1",
     "bignumber.js": "^9.0.1",
-    "blockchain-addressbook": "^0.46.203",
+    "blockchain-addressbook": "^0.46.204",
     "clsx": "^1.1.1",
     "date-fns": "^2.29.3",
     "eip-712": "^1.0.0",

--- a/src/config/vault/base.json
+++ b/src/config/vault/base.json
@@ -1,5 +1,131 @@
 [
   {
+    "id": "aero-cow-ezeth-weth-rp",
+    "name": "ezETH-WETH Reward Pool",
+    "type": "gov",
+    "version": 2,
+    "token": "cowAeroezETH-WETH",
+    "tokenAddress": "0x2f2b7bCd8fef71D48Bbc31237a058fAdFBA39124",
+    "tokenDecimals": 18,
+    "earnedTokens": ["AERO"],
+    "earnedTokenAddresses": [
+      "0x940181a94A35A4569E4529A3CDfB74e38FD98631",
+      "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    ],
+    "earnedOracleIds": ["AERO", "USDC"],
+    "earnedTokenDecimals": [18, 6],
+    "earnedToken": "rcowAeroezETH-WETH",
+    "earnContractAddress": "0x71476637f250e25943c4Cc8c9768F831a0740533",
+    "oracle": "lps",
+    "oracleId": "aero-cow-ezeth-weth",
+    "status": "active",
+    "createdAt": 1721223701,
+    "platformId": "aerodrome",
+    "assets": ["ezETH", "WETH"],
+    "risks": [],
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "gov-composer"
+      }
+    ]
+  },
+  {
+    "id": "aero-cow-ezeth-weth",
+    "name": "ezETH-WETH",
+    "token": "ezETH-WETH",
+    "tokenAddress": "0xDC7EAd706795eDa3FEDa08Ad519d9452BAdF2C0d",
+    "tokenDecimals": 18,
+    "depositTokenAddresses": [
+      "0x2416092f143378750bb29b79eD961ab195CcEea5",
+      "0x4200000000000000000000000000000000000006"
+    ],
+    "tokenProviderId": "aerodrome",
+    "earnedToken": "cowAeroezETH-WETH",
+    "earnedTokenAddress": "0x2f2b7bCd8fef71D48Bbc31237a058fAdFBA39124",
+    "earnContractAddress": "0x2f2b7bCd8fef71D48Bbc31237a058fAdFBA39124",
+    "oracle": "lps",
+    "oracleId": "aero-cow-ezeth-weth",
+    "status": "active",
+    "createdAt": 1720979963,
+    "platformId": "beefy",
+    "assets": ["ezETH", "WETH"],
+    "risks": ["IL_NONE", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
+    "strategyTypeId": "pool",
+    "network": "base",
+    "type": "cowcentrated",
+    "feeTier": "0.30",
+    "zaps": [
+      {
+        "strategyId": "cowcentrated"
+      }
+    ]
+  },
+  {
+    "id": "aero-cow-dola-usd+-rp",
+    "name": "DOLA-USD+ Reward Pool",
+    "type": "gov",
+    "version": 2,
+    "token": "cowAeroDOLA-USD+",
+    "tokenAddress": "0x39f663b3DFfe3824E6a2a14819a5Db08b353D78f",
+    "tokenDecimals": 18,
+    "earnedTokens": ["AERO"],
+    "earnedTokenAddresses": [
+      "0x940181a94A35A4569E4529A3CDfB74e38FD98631",
+      "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    ],
+    "earnedOracleIds": ["AERO", "USDC"],
+    "earnedTokenDecimals": [18, 6],
+    "earnedToken": "rcowAeroDOLA-USD+",
+    "earnContractAddress": "0x11CFB67123dbd8cc585e7b8664eeC20409f1D1A0",
+    "oracle": "lps",
+    "oracleId": "aero-cow-dola-usd+",
+    "status": "active",
+    "createdAt": 1721219183,
+    "platformId": "aerodrome",
+    "assets": ["DOLA", "USD+"],
+    "risks": [],
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "gov-composer"
+      }
+    ]
+  },
+  {
+    "id": "aero-cow-dola-usd+",
+    "name": "DOLA-USD+",
+    "token": "DOLA-USD+",
+    "tokenAddress": "0x96331Fcb46A7757854d9E26AFf3aCA2815D623fD",
+    "tokenDecimals": 18,
+    "depositTokenAddresses": [
+      "0x4621b7A9c75199271F773Ebd9A499dbd165c3191",
+      "0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376"
+    ],
+    "tokenProviderId": "aerodrome",
+    "earnedToken": "cowAeroDOLA-USD+",
+    "earnedTokenAddress": "0x39f663b3DFfe3824E6a2a14819a5Db08b353D78f",
+    "earnContractAddress": "0x39f663b3DFfe3824E6a2a14819a5Db08b353D78f",
+    "oracle": "lps",
+    "oracleId": "aero-cow-dola-usd+",
+    "status": "active",
+    "createdAt": 1720794757,
+    "platformId": "beefy",
+    "assets": ["DOLA", "USD+"],
+    "risks": ["IL_NONE", "MCAP_MEDIUM", "CONTRACTS_VERIFIED"],
+    "strategyTypeId": "pool",
+    "network": "base",
+    "type": "cowcentrated",
+    "feeTier": "0.30",
+    "zaps": [
+      {
+        "strategyId": "cowcentrated"
+      }
+    ]
+  },
+  {
     "id": "aerodrome-usdz-susdz",
     "name": "USDz-sUSDz vLP",
     "token": "vAMM-USDz/sUSDz",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2830,10 +2830,10 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.2.1.tgz#5057e4206eadb4a97f7c0b6e197a505042fc3814"
   integrity sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==
 
-blockchain-addressbook@^0.46.203:
-  version "0.46.203"
-  resolved "https://registry.yarnpkg.com/blockchain-addressbook/-/blockchain-addressbook-0.46.203.tgz#14af3cef34b3fb6e3c302440ac43ff6a8a5d4131"
-  integrity sha512-Xf2W0VUFnZRaITJHPIC1PHkTf21d3vH5lUgSr02wUAhK7bEtOib7rZGHqObRZVwCSaCIrHunJ5GadppQa9NZtg==
+blockchain-addressbook@^0.46.204:
+  version "0.46.204"
+  resolved "https://registry.yarnpkg.com/blockchain-addressbook/-/blockchain-addressbook-0.46.204.tgz#c21448fa4f3163a09b4524fb4005acabea41263a"
+  integrity sha512-wOLlASTeV+EOnHUCnqN/owW3VqCxxXd+anSk1XLUhdQEAyBTB9rwvos7Q1rXlA00nJAQWj4ZmHgKpbLWj6/diQ==
 
 bluebird@^3.5.0:
   version "3.7.2"


### PR DESCRIPTION
Hey team, these vaults failed `yarn validate` because the subOracle needed to be set for `ezETH` 0x2416092f143378750bb29b79eD961ab195CcEea5 and `DOLA` 0x4621b7A9c75199271F773Ebd9A499dbd165c3191 in beefyOracle, but I don't have permission to do, could you help with that? Thanks. 