### PR TITLE
Hide slippage on vault to rewardpool zap

### DIFF
--- a/src/features/data/apis/transact/transact-types.ts
+++ b/src/features/data/apis/transact/transact-types.ts
@@ -687,6 +687,13 @@ export function isWithdrawQuote(quote: TransactQuote): quote is WithdrawQuote {
   return quote.option.mode === TransactMode.Withdraw;
 }
 
+export function quoteNeedsSlippage(quote: TransactQuote): boolean {
+  if (quote.strategyId === 'reward-pool-to-vault') {
+    return false;
+  }
+  return isZapQuote(quote) || isCowcentratedVaultWithdrawQuote(quote);
+}
+
 export interface ITransactApi {
   fetchDepositOptionsFor(
     vaultId: VaultEntity['id'],

--- a/src/features/vault/components/Actions/Transact/TransactQuote/TransactQuote.tsx
+++ b/src/features/vault/components/Actions/Transact/TransactQuote/TransactQuote.tsx
@@ -24,8 +24,8 @@ import {
   type CowcentratedVaultDepositQuote,
   type CowcentratedZapDepositQuote,
   isCowcentratedDepositQuote,
-  isCowcentratedVaultWithdrawQuote,
   isZapQuote,
+  quoteNeedsSlippage,
 } from '../../../../../data/apis/transact/transact-types';
 import { ZapRoute } from '../ZapRoute';
 import { QuoteTitleRefresh } from '../QuoteTitleRefresh';
@@ -183,7 +183,7 @@ const QuoteLoaded = memo(function QuoteLoaded() {
   const classes = useStyles();
   const quote = useAppSelector(selectTransactSelectedQuote);
   const isZap = isZapQuote(quote);
-  const needsSlippage = isZap || isCowcentratedVaultWithdrawQuote(quote);
+  const needsSlippage = quoteNeedsSlippage(quote);
 
   return (
     <>


### PR DESCRIPTION
Hide slippage selecting component from the deposit form when performing vault to rewardpool and rewardpool to vault zaps. Liquidity is just being moved around so there isn't an expectation of any slippage happening on such a transaction