### PR TITLE
Fix CowcentratedRanges token display order

### DIFF
--- a/src/features/dashboard/components/UserVaults/components/VaultTransactions/components/Transaction/Transaction.tsx
+++ b/src/features/dashboard/components/UserVaults/components/VaultTransactions/components/Transaction/Transaction.tsx
@@ -69,7 +69,7 @@ const CowcentratedAmountStat = memo<TransactionStatProps<TimelineEntryCowcentrat
   function CowcentratedAmountStat({ tx, mobile }) {
     const classes = useStyles();
     const { underlying0Diff, underlying1Diff } = tx;
-    const { token0, token1 } = useAppSelector(state =>
+    const [token0, token1] = useAppSelector(state =>
       selectCowcentratedLikeVaultDepositTokens(state, tx.vaultId)
     );
     const variant0 = underlying0Diff.isZero()
@@ -156,7 +156,7 @@ const CowcentratedBalanceStat = memo<TransactionStatProps<TimelineEntryCowcentra
   function CowcentratedBalanceStat({ tx, mobile }) {
     const classes = useStyles();
     const { underlying0Balance, underlying1Balance } = tx;
-    const { token0, token1 } = useAppSelector(state =>
+    const [token0, token1] = useAppSelector(state =>
       selectCowcentratedLikeVaultDepositTokens(state, tx.vaultId)
     );
 

--- a/src/features/data/actions/analytics.ts
+++ b/src/features/data/actions/analytics.ts
@@ -970,7 +970,7 @@ export const recalculateClmPoolHarvestsForUserVaultId = createAsyncThunk<
   'analytics/recalculateClmPoolHarvestsForUserVaultId',
   async ({ walletAddress, vaultId }, { getState }) => {
     const state = getState();
-    const { token0, token1 } = selectCowcentratedLikeVaultDepositTokens(state, vaultId);
+    const [token0, token1] = selectCowcentratedLikeVaultDepositTokens(state, vaultId);
     const result: RecalculateClmHarvestsForUserVaultIdPayload = {
       vaultId,
       walletAddress,
@@ -1075,7 +1075,7 @@ export const fetchClmPendingRewards = createAsyncThunk<
 >('analytics/fetchClmPendingRewards', async ({ vaultId }, { getState }) => {
   const state = getState();
   const vault = selectCowcentratedLikeVaultById(state, vaultId);
-  const { token0, token1 } = selectCowcentratedLikeVaultDepositTokens(state, vaultId);
+  const [token0, token1] = selectCowcentratedLikeVaultDepositTokens(state, vaultId);
   const clmStrategyAddress = selectVaultStrategyAddressOrUndefined(
     state,
     vault.cowcentratedIds.clm

--- a/src/features/data/actions/balance.ts
+++ b/src/features/data/actions/balance.ts
@@ -100,8 +100,8 @@ export const fetchBalanceAction = createAsyncThunk<
           govVaults.push(vault);
         } else {
           if (isCowcentratedLikeVault(vault)) {
-            Object.values(selectCowcentratedLikeVaultDepositTokens(state, vault.id)).forEach(
-              token => tokens.push(token)
+            selectCowcentratedLikeVaultDepositTokens(state, vault.id).forEach(token =>
+              tokens.push(token)
             );
           }
           if (!isCowcentratedVault(vault)) {

--- a/src/features/data/selectors/analytics.ts
+++ b/src/features/data/selectors/analytics.ts
@@ -293,7 +293,7 @@ export const selectClmPnl = (
     vault.chainId,
     vault.depositTokenAddress
   );
-  const { token0, token1 } = selectCowcentratedLikeVaultDepositTokens(state, vaultId);
+  const [token0, token1] = selectCowcentratedLikeVaultDepositTokens(state, vaultId);
   const breakdown = selectLpBreakdownForVault(state, vault);
   const { assets, userBalanceDecimal: underlyingNow } = selectUserLpBreakdownBalance(
     state,
@@ -628,7 +628,7 @@ export const selectClmAutocompoundedPendingFeesByVaultId = (
   vaultId: VaultEntity['id'],
   walletAddress?: string
 ) => {
-  const { token0, token1 } = selectCowcentratedLikeVaultDepositTokensWithPrices(state, vaultId);
+  const [token0, token1] = selectCowcentratedLikeVaultDepositTokensWithPrices(state, vaultId);
   const { price: token0Price, symbol: token0Symbol, decimals: token0Decimals } = token0;
   const { price: token1Price, symbol: token1Symbol, decimals: token1Decimals } = token1;
 

--- a/src/features/vault/components/HistoricGraph/CurrentCowcentratedRange/CurrentCowcentratedRange.tsx
+++ b/src/features/vault/components/HistoricGraph/CurrentCowcentratedRange/CurrentCowcentratedRange.tsx
@@ -1,11 +1,11 @@
 import { formatTokenDisplayCondensed } from '../../../../../helpers/format';
-import { makeStyles, useMediaQuery, type Theme } from '@material-ui/core';
+import { makeStyles, type Theme, useMediaQuery } from '@material-ui/core';
 import { useAppSelector } from '../../../../../store';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
+  selectCowcentratedLikeVaultDepositTokens,
   selectCurrentCowcentratedRangesByVaultId,
-  selectVaultTokenSymbols,
 } from '../../../../data/selectors/tokens';
 import type { VaultEntity } from '../../../../data/entities/vault';
 import { styles } from './styles';
@@ -82,8 +82,13 @@ export const CurrentCowcentratedRange = memo<CurrentCowcentratedRangeProps>(
     const classes = useStyles();
     const { t } = useTranslation();
     const { currentPrice, priceRangeMin, priceRangeMax } = range;
-    const symbols = useAppSelector(state => selectVaultTokenSymbols(state, vaultId));
-    const priceString = `${symbols[inverted ? 0 : 1]}/${symbols[inverted ? 1 : 0]}`;
+    const tokens = useAppSelector(state =>
+      selectCowcentratedLikeVaultDepositTokens(state, vaultId)
+    );
+    const priceString = useMemo(() => {
+      const symbols = tokens.map(t => t.symbol);
+      return `${symbols[inverted ? 0 : 1]}/${symbols[inverted ? 1 : 0]}`;
+    }, [tokens, inverted]);
     const showInRange = useMemo(() => {
       return currentPrice.lte(priceRangeMax) && currentPrice.gte(priceRangeMin);
     }, [currentPrice, priceRangeMax, priceRangeMin]);

--- a/src/features/vault/components/PnLGraph/cowcentrated/components/Footers/Footer.tsx
+++ b/src/features/vault/components/PnLGraph/cowcentrated/components/Footers/Footer.tsx
@@ -75,7 +75,7 @@ export const FeesFooter = memo<FooterProps>(function Footer({
   className,
 }) {
   const classes = useStyles();
-  const { token0, token1 } = useAppSelector(state =>
+  const [token0, token1] = useAppSelector(state =>
     selectCowcentratedLikeVaultDepositTokens(state, vaultId)
   );
 

--- a/src/features/vault/components/PnLGraph/cowcentrated/components/OverviewGraph/hooks.tsx
+++ b/src/features/vault/components/PnLGraph/cowcentrated/components/OverviewGraph/hooks.tsx
@@ -155,7 +155,7 @@ export const usePnLChartData = (
   const nowPriceUnderlying = useAppSelector(state =>
     selectTokenPriceByTokenOracleId(state, depositToken.oracleId)
   );
-  const { token0, token1 } = useAppSelector(state =>
+  const [token0, token1] = useAppSelector(state =>
     selectCowcentratedLikeVaultDepositTokensWithPrices(state, vaultId)
   );
   const nowPriceToken0 = token0.price;


### PR DESCRIPTION
Was using assets array (instead of depositTokenAddresses), which isn't always in token order.

Example: https://app.beefy.com/vault/uniswap-cow-base-weth-talent-rp

Also, memoize selectCowcentratedLikeVaultDepositTokens to avoid some re-renders