### PR TITLE
Show CLM Pool as 'Total APY' if clmApr > 0, otherwise 'Total APR'

### DIFF
--- a/src/components/Banners/RetiredSuggestClmBanner/RetiredSuggestClmBanner.tsx
+++ b/src/components/Banners/RetiredSuggestClmBanner/RetiredSuggestClmBanner.tsx
@@ -114,7 +114,7 @@ const VaultLink = memo(function VaultLink({ vaultId }: { vaultId: VaultEntity['i
   const vault = useAppSelector(state => selectVaultById(state, vaultId));
   const platform = useAppSelector(state => selectPlatformById(state, vault.platformId));
   const apy = useAppSelector(state => selectVaultTotalApy(state, vaultId));
-  const apyLabel = vault.type == 'gov' && vault.strategyTypeId !== 'compounds' ? 'APR' : 'APY';
+  const apyLabel = apy.totalType.toUpperCase();
 
   return (
     <Trans

--- a/src/components/VaultStats/VaultApyStat.tsx
+++ b/src/components/VaultStats/VaultApyStat.tsx
@@ -1,12 +1,10 @@
 import { type VaultEntity } from '../../features/data/entities/vault';
 import { memo, useMemo } from 'react';
 import { selectVaultById } from '../../features/data/selectors/vaults';
-import { formatTotalApy } from '../../helpers/format';
+import { type FormattedTotalApy, formatTotalApy } from '../../helpers/format';
 import { VaultValueStat, type VaultValueStatProps } from '../VaultValueStat';
 import { selectApyVaultUIData } from '../../features/data/selectors/apy';
 import { useAppSelector } from '../../store';
-import type { AllValuesAsString } from '../../features/data/utils/types-utils';
-import type { TotalApy } from '../../features/data/reducers/apy';
 import { InterestTooltipContent } from '../InterestTooltipContent';
 import { getApyComponents, getApyLabelsForType, getApyLabelsTypeForVault } from '../../helpers/apy';
 import { useTranslation } from 'react-i18next';
@@ -79,7 +77,7 @@ type ApyTooltipContentProps = {
   vaultId: VaultEntity['id'];
   type: 'yearly' | 'daily';
   isBoosted: boolean;
-  rates: AllValuesAsString<TotalApy>;
+  rates: FormattedTotalApy;
 };
 
 export const ApyTooltipContent = memo<ApyTooltipContentProps>(function ApyTooltipContent({
@@ -90,7 +88,7 @@ export const ApyTooltipContent = memo<ApyTooltipContentProps>(function ApyToolti
 }) {
   const vault = useAppSelector(state => selectVaultById(state, vaultId));
   const rows = useMemo(() => {
-    const labels = getApyLabelsForType(getApyLabelsTypeForVault(vault));
+    const labels = getApyLabelsForType(getApyLabelsTypeForVault(vault, rates.totalType));
     const allComponents = getApyComponents();
     const components = allComponents[type];
     const totalKey = type === 'daily' ? 'totalDaily' : 'totalApy';

--- a/src/features/data/reducers/apy.ts
+++ b/src/features/data/reducers/apy.ts
@@ -24,6 +24,7 @@ interface AprData {
 // TODO: this should be reworked
 export interface TotalApy {
   totalApy: number;
+  totalType: 'apy' | 'apr';
   totalMonthly: number;
   totalDaily: number;
   vaultApr?: number;
@@ -53,7 +54,7 @@ export interface TotalApy {
 }
 
 type ExtractAprComponents<T extends string> = T extends `${infer C}Apr` ? C : never;
-export type TotalApyKey = keyof TotalApy;
+export type TotalApyKey = Exclude<keyof TotalApy, 'totalType'>;
 export type TotalApyComponent = ExtractAprComponents<TotalApyKey>;
 export type TotalApyYearlyComponent = `${TotalApyComponent}Apr`;
 export type TotalApyDailyComponent = `${TotalApyComponent}Daily`;

--- a/src/features/data/selectors/apy.ts
+++ b/src/features/data/selectors/apy.ts
@@ -31,6 +31,7 @@ const EMPTY_TOTAL_APY: TotalApy = {
   totalApy: 0,
   totalMonthly: 0,
   totalDaily: 0,
+  totalType: 'apy',
 };
 
 export const selectVaultTotalApyOrUndefined = (
@@ -275,7 +276,7 @@ export function selectApyVaultUIData(
 
   return {
     status: 'available',
-    type: vault.strategyTypeId === 'compounds' ? 'apy' : 'apr',
+    type: values.totalType,
     values,
     boosted: 'boostedTotalDaily' in values ? 'active' : undefined,
   };

--- a/src/features/vault/components/Explainer/Cowcentrated/CowcentratedExplainer.tsx
+++ b/src/features/vault/components/Explainer/Cowcentrated/CowcentratedExplainer.tsx
@@ -91,7 +91,9 @@ export const CowcentratedExplainer = memo<CowcentratedExplainerProps>(
         links={links}
         description={<CowcentratedLikeDescription vaultId={vaultId} />}
         details={
-          showApy ? <ApyDetails type={getApyLabelsTypeForVault(vault)} values={apys} /> : undefined
+          showApy ? (
+            <ApyDetails type={getApyLabelsTypeForVault(vault, apys.totalType)} values={apys} />
+          ) : undefined
         }
       />
     );

--- a/src/features/vault/components/Explainer/Standard/StandardExplainer.tsx
+++ b/src/features/vault/components/Explainer/Standard/StandardExplainer.tsx
@@ -64,7 +64,9 @@ export const StandardExplainer = memo<StandardExplainerProps>(function StandardE
       description={<StandardDescription vaultId={vaultId} />}
       details={
         <>
-          {showApy ? <ApyDetails type={getApyLabelsTypeForVault(vault)} values={apys} /> : null}
+          {showApy ? (
+            <ApyDetails type={getApyLabelsTypeForVault(vault, apys.totalType)} values={apys} />
+          ) : null}
           {showLendingOracle ? <LendingOracle vaultId={vault.id} /> : null}
         </>
       }

--- a/src/helpers/apy.ts
+++ b/src/helpers/apy.ts
@@ -132,8 +132,11 @@ export const getApiApyDataComponents = createFactory(() => {
   } as const;
 });
 
-export function getApyLabelsTypeForVault(vault: VaultEntity): ApyLabelsType {
-  if (isCowcentratedGovVault(vault) && vault.strategyTypeId === 'compounds') {
+export function getApyLabelsTypeForVault(
+  vault: VaultEntity,
+  totalType: 'apy' | 'apr'
+): ApyLabelsType {
+  if (isCowcentratedGovVault(vault) && totalType === 'apy') {
     return 'cowcentrated-compounds';
   }
 

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -269,14 +269,15 @@ export function formatLargeUsd(
   return `${prefix}${formatLargeNumber(value.absoluteValue(), largeOptions)}`;
 }
 
-export function formatTotalApy(
-  totalApy: TotalApy,
-  placeholder?: string
-): AllValuesAs<TotalApy, string>;
+export type FormattedTotalApy<T = string> = {
+  [K in keyof TotalApy]: TotalApy[K] extends T ? TotalApy[K] : T;
+};
+
+export function formatTotalApy(totalApy: TotalApy, placeholder?: string): FormattedTotalApy;
 export function formatTotalApy(
   totalApy: TotalApy,
   placeholder?: ReactNode
-): AllValuesAs<TotalApy, ReactNode>;
+): FormattedTotalApy<ReactNode>;
 /**
  * Formats a TotalApy object to a string for display
  */
@@ -286,9 +287,12 @@ export function formatTotalApy(
 ): AllValuesAs<TotalApy, string | ReactNode> {
   return Object.fromEntries(
     strictEntries(totalApy).map(([key, value]) => {
-      const formattedValue = key.toLowerCase().includes('daily')
-        ? formatLargePercent(value, 4, placeholder)
-        : formatLargePercent(value, 2, placeholder);
+      const formattedValue =
+        key === 'totalType'
+          ? value
+          : key.toLowerCase().includes('daily')
+          ? formatLargePercent(value, 4, placeholder)
+          : formatLargePercent(value, 2, placeholder);
       return [key, formattedValue];
     })
   ) as AllValuesAs<TotalApy, string | ReactNode>; // required keys in input so should exist in output


### PR DESCRIPTION
CLM Vaults / other vaults should not be effected by this change

## Velodrome / Aerodrome
Only send fee rewards to pool, so should always be Total APR

## Uniswap / Sushi / Thena / Camelot / Stellaswap / Baseswap / Oku / Kim / Dragon
Only compound fees in base CLM, so should always be Total APY

## Ramses / Pharoah / Nile / Pancakeswap / Nuri / Shadow
Compounds some fees, and sometimes have rewards sent to pool.
Should show Total APY if compounded fees (clmApr aka Trading Fees APR) > 0, otherwise Total  APR