### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -55,7 +55,7 @@ const socialLinks = [
   },
   {
     title: 'Twitter',
-    path: 'https://twitter.com/beefyfinance',
+    path: 'https://x.com/beefyfinance',
     Icon: IconTwitter,
   },
   {

--- a/src/config/boost/campaigns.json
+++ b/src/config/boost/campaigns.json
@@ -3,7 +3,7 @@
     "description": "Lido and Renzo joined forces with Beefy to bring users earnings competely denominated in ETH. Earn ezETH and wstETH on top of your ezETH-wstETH position.",
     "social": {
       "discord": "https://beefy.com/discord",
-      "twitter": "https://twitter.com/beefyfinance"
+      "twitter": "https://x.com/beefyfinance"
     }
   },
   "rootstock-grant": {
@@ -12,7 +12,7 @@
     "description": "Celebrate the launch of Beefy on Rootstock, Bitcoin's first and longest-lasting sidechain. Beefy users can earn grant-funded $rBTC tokens for trying out new products on Rootstock. Rewards accrue linearly over time, depending on the user's TVL. Simply use the 'Boost Vault' button in the BOOST module to enter the boost, and then manually claim your rewards whenever you're ready.",
     "social": {
       "discord": "https://beefy.com/discord",
-      "twitter": "https://twitter.com/beefyfinance"
+      "twitter": "https://x.com/beefyfinance"
     }
   },
   "arb-ltipp": {
@@ -21,7 +21,7 @@
     "learn": "https://beefy.com/articles/ltipp/",
     "social": {
       "discord": "https://beefy.com/discord",
-      "twitter": "https://twitter.com/beefyfinance"
+      "twitter": "https://x.com/beefyfinance"
     }
   },
   "zap-v3": {
@@ -32,7 +32,7 @@
     "learn": "https://beefy.com/articles/zap-v3/",
     "social": {
       "discord": "https://beefy.com/discord",
-      "twitter": "https://twitter.com/beefyfinance"
+      "twitter": "https://x.com/beefyfinance"
     }
   },
   "offchain-zap-v3": {
@@ -43,7 +43,7 @@
     "learn": "https://beefy.com/articles/zap-v3/",
     "social": {
       "discord": "https://beefy.com/discord",
-      "twitter": "https://twitter.com/beefyfinance"
+      "twitter": "https://x.com/beefyfinance"
     }
   },
   "offchain-mode-grant": {
@@ -52,7 +52,7 @@
     "description": "Earn $OP on Optimism network for participating in Beefy vaults on Mode. Beefy users earn additional $OP tokens for using products on the Superchain. Rewards accrue linearly over time depending on the user's TVL. Simply click the 'Claim' tab to find details of all onchain and offchain rewards, and then manually claim your rewards whenever you're ready.",
     "social": {
       "discord": "https://beefy.com/discord",
-      "twitter": "https://twitter.com/beefyfinance"
+      "twitter": "https://x.com/beefyfinance"
     }
   },
   "dao-rewards": {
@@ -61,7 +61,7 @@
     "learn": "https://snapshot.org/#/beefydao.eth/proposal/0xefe70f50c7743085e72f4c2421cc8e92c8b82fa14bfd479a26bd0a0c14c5f07e",
     "social": {
       "discord": "https://beefy.com/discord",
-      "twitter": "https://twitter.com/beefyfinance"
+      "twitter": "https://x.com/beefyfinance"
     }
   },
   "optimism-grant": {
@@ -70,7 +70,7 @@
     "learn": "https://beefy.com/articles/beefy-helps-grow-the-optimism-community-with-a-650-000-op-grant/",
     "social": {
       "discord": "https://beefy.com/discord",
-      "twitter": "https://twitter.com/beefyfinance"
+      "twitter": "https://x.com/beefyfinance"
     }
   }
 }

--- a/src/config/boost/partners.json
+++ b/src/config/boost/partners.json
@@ -14,7 +14,7 @@
     "website": "https://app.beefy.finance",
     "social": {
       "telegram": "http://t.me/beefyfinance",
-      "twitter": "https://twitter.com/beefyfinance"
+      "twitter": "https://x.com/beefyfinance"
     }
   },
   "balancer": {
@@ -41,7 +41,7 @@
     "website": "https://gains.trade/",
     "social": {
       "discord": "https://discord.com/invite/gains-network",
-      "twitter": "https://twitter.com/GainsNetwork_io"
+      "twitter": "https://x.com/GainsNetwork_io"
     }
   },
   "arbitrum": {
@@ -50,7 +50,7 @@
     "website": "https://arbitrum.io/",
     "social": {
       "discord": "https://discord.gg/arbitrum",
-      "twitter": "https://twitter.com/arbitrum"
+      "twitter": "https://x.com/arbitrum"
     }
   },
   "pendle": {
@@ -59,7 +59,7 @@
     "website": "https://www.pendle.finance/",
     "social": {
       "telegram": "https://t.me/pendlefinance",
-      "twitter": "https://twitter.com/pendle_fi"
+      "twitter": "https://x.com/pendle_fi"
     }
   },
   "vectorreserve": {
@@ -77,7 +77,7 @@
     "website": "https://www.silo.finance/",
     "social": {
       "discord": "https://discord.gg/silo-finance",
-      "twitter": "https://twitter.com/SiloFinance"
+      "twitter": "https://x.com/SiloFinance"
     }
   },
   "curve": {
@@ -86,7 +86,7 @@
     "website": "https://curve.fi/",
     "social": {
       "telegram": "https://t.me/curvefi",
-      "twitter": "https://twitter.com/CurveFinance"
+      "twitter": "https://x.com/CurveFinance"
     }
   },
   "fraxprotocol": {
@@ -95,7 +95,7 @@
     "website": "https://app.frax.finance/",
     "social": {
       "telegram": "https://t.me/fraxfinance",
-      "twitter": "https://twitter.com/fraxfinance"
+      "twitter": "https://x.com/fraxfinance"
     }
   },
   "lendle": {
@@ -104,7 +104,7 @@
     "website": "https://www.lendle.xyz/",
     "social": {
       "discord": "https://t.co/FuQvdakeFk",
-      "twitter": "https://twitter.com/lendlexyz"
+      "twitter": "https://x.com/lendlexyz"
     }
   },
   "frax": {
@@ -113,7 +113,7 @@
     "website": "https://app.frax.finance/",
     "social": {
       "telegram": "https://t.me/fraxfinance",
-      "twitter": "https://twitter.com/fraxfinance"
+      "twitter": "https://x.com/fraxfinance"
     }
   },
   "sonne": {
@@ -122,7 +122,7 @@
     "website": "https://sonne.finance/",
     "social": {
       "discord": "https://discord.gg/sonnefinance",
-      "twitter": "https://twitter.com/SonneFinance"
+      "twitter": "https://x.com/SonneFinance"
     }
   },
   "threshold": {
@@ -131,7 +131,7 @@
     "website": "https://threshold.network/",
     "social": {
       "discord": "https://discord.gg/Threshold",
-      "twitter": "https://twitter.com/TheTNetwork"
+      "twitter": "https://x.com/TheTNetwork"
     }
   },
   "angle": {
@@ -140,7 +140,7 @@
     "website": "https://angle.money/",
     "social": {
       "discord": "https://discord.gg/5Af6xum9bc",
-      "twitter": "https://twitter.com/AngleProtocol"
+      "twitter": "https://x.com/AngleProtocol"
     }
   },
   "stafi": {
@@ -149,7 +149,7 @@
     "website": "https://www.stafi.io/",
     "social": {
       "discord": "https://discord.com/invite/jB77etn",
-      "twitter": "https://twitter.com/Stafi_Protocol"
+      "twitter": "https://x.com/Stafi_Protocol"
     }
   },
   "thales": {
@@ -158,7 +158,7 @@
     "website": "https://thalesmarket.io/",
     "social": {
       "discord": "https://discord.com/invite/rB3AWKwACM",
-      "twitter": "https://twitter.com/ThalesMarket"
+      "twitter": "https://x.com/ThalesMarket"
     }
   },
   "lyra": {
@@ -167,7 +167,7 @@
     "website": "https://app.lyra.finance/",
     "social": {
       "discord": "https://discord.gg/P49mj6UbmC",
-      "twitter": "https://twitter.com/lyrafinance"
+      "twitter": "https://x.com/lyrafinance"
     }
   },
   "kinetix": {
@@ -176,7 +176,7 @@
     "website": "https://kinetix.finance/",
     "social": {
       "discord": "https://discord.com/invite/kinetixfi",
-      "twitter": "https://twitter.com/KinetixFi"
+      "twitter": "https://x.com/KinetixFi"
     }
   },
   "retro": {
@@ -185,7 +185,7 @@
     "website": "https://retro.finance/",
     "social": {
       "discord": "https://discord.gg/stabllabs",
-      "twitter": "https://twitter.com/Retro_finance"
+      "twitter": "https://x.com/Retro_finance"
     }
   },
   "tangible": {
@@ -194,7 +194,7 @@
     "website": "https://www.tangible.store/caviar",
     "social": {
       "telegram": "https://t.me/TangibleDAO",
-      "twitter": "https://twitter.com/tangibleDAO"
+      "twitter": "https://x.com/tangibleDAO"
     }
   },
   "alienbase": {
@@ -203,7 +203,7 @@
     "website": "https://app.alienbase.xyz/swap",
     "social": {
       "telegram": "https://t.me/+NhjwXlgSEPRhZGQx",
-      "twitter": "https://twitter.com/alienbaseDEX"
+      "twitter": "https://x.com/alienbaseDEX"
     }
   },
   "exactly": {
@@ -212,7 +212,7 @@
     "website": "https://exact.ly/",
     "social": {
       "telegram": "https://t.me/exactlyFinance",
-      "twitter": "https://twitter.com/exactlyprotocol"
+      "twitter": "https://x.com/exactlyprotocol"
     }
   },
   "stargate": {
@@ -221,7 +221,7 @@
     "website": "https://stargate.finance/",
     "social": {
       "telegram": "https://t.me/joinchat/LEM0ELklmO1kODdh",
-      "twitter": "https://twitter.com/StargateFinance"
+      "twitter": "https://x.com/StargateFinance"
     }
   },
   "kwenta": {
@@ -230,7 +230,7 @@
     "website": "https://kwenta.eth.limo/",
     "social": {
       "discord": "https://discord.com/invite/kwentaio",
-      "twitter": "https://twitter.com/kwenta_io"
+      "twitter": "https://x.com/kwenta_io"
     }
   },
   "optimism": {
@@ -239,7 +239,7 @@
     "website": "https://www.optimism.io/",
     "social": {
       "discord": "https://discord.com/invite/optimism",
-      "twitter": "https://twitter.com/optimismFND"
+      "twitter": "https://x.com/optimismFND"
     }
   },
   "tprotocol": {
@@ -248,7 +248,7 @@
     "website": "https://www.tprotocol.io/",
     "social": {
       "discord": "https://discord.com/invite/ZEV6PNXK9Q",
-      "twitter": "https://twitter.com/TProtocol_"
+      "twitter": "https://x.com/TProtocol_"
     }
   },
   "scanto": {
@@ -257,7 +257,7 @@
     "website": "https://scanto.io",
     "social": {
       "discord": "https://discord.com/invite/scanto",
-      "twitter": "https://twitter.com/stakedCANTO"
+      "twitter": "https://x.com/stakedCANTO"
     }
   },
   "overnight": {
@@ -266,7 +266,7 @@
     "website": "https://overnight.fi/",
     "social": {
       "discord": "https://discord.gg/overnight-fi",
-      "twitter": "https://twitter.com/overnight_fi"
+      "twitter": "https://x.com/overnight_fi"
     }
   },
   "carbon": {
@@ -275,7 +275,7 @@
     "website": "https://carbon.website/",
     "social": {
       "telegram": "https://t.me/trycarbonio",
-      "twitter": "https://twitter.com/trycarbonio"
+      "twitter": "https://x.com/trycarbonio"
     }
   },
   "mimo": {
@@ -284,7 +284,7 @@
     "website": "https://app.mimo.capital/",
     "social": {
       "telegram": "https://t.me/mimo_labs",
-      "twitter": "https://twitter.com/mimo_dao"
+      "twitter": "https://x.com/mimo_dao"
     }
   },
   "kava": {
@@ -294,7 +294,7 @@
     "social": {
       "discord": "https://discord.com/invite/q6QuanE4bx",
       "telegram": "https://t.me/kavalabs",
-      "twitter": "https://twitter.com/kava_platform"
+      "twitter": "https://x.com/kava_platform"
     }
   },
   "metavault": {
@@ -303,7 +303,7 @@
     "website": "https://metavault.trade/",
     "social": {
       "discord": "https://discord.gg/metavault",
-      "twitter": "https://twitter.com/MetavaultTRADE/"
+      "twitter": "https://x.com/MetavaultTRADE/"
     }
   },
   "opx": {
@@ -312,7 +312,7 @@
     "website": "https://www.opx.finance/",
     "social": {
       "discord": "https://discord.gg/mNdHE52zZp",
-      "twitter": "https://twitter.com/opxfinance"
+      "twitter": "https://x.com/opxfinance"
     }
   },
   "synthetix": {
@@ -321,7 +321,7 @@
     "website": "https://synthetix.io/",
     "social": {
       "discord": "https://discord.com/invite/AEdUHzt",
-      "twitter": "https://twitter.com/synthetix_io"
+      "twitter": "https://x.com/synthetix_io"
     }
   },
   "velodrome": {
@@ -330,7 +330,7 @@
     "website": "https://velodrome.finance/swap",
     "social": {
       "discord": "https://discord.com/invite/velodrome",
-      "twitter": "https://twitter.com/VelodromeFi"
+      "twitter": "https://x.com/VelodromeFi"
     }
   },
   "stader": {
@@ -340,7 +340,7 @@
     "social": {
       "telegram": "https://t.me/StaderLabs_Polygon_Official",
       "discord": "https://discord.com/invite/ReasyJB4Rq",
-      "twitter": "https://twitter.com/stader_polygon"
+      "twitter": "https://x.com/stader_polygon"
     }
   },
   "stader-bsc": {
@@ -349,7 +349,7 @@
     "website": "https://www.staderlabs.com/bnb/stake/",
     "social": {
       "telegram": "https://t.me/staderlabs_bnb_official",
-      "twitter": "https://twitter.com/stader_bnb"
+      "twitter": "https://x.com/stader_bnb"
     }
   },
   "swapsicle": {
@@ -358,7 +358,7 @@
     "website": "https://www.swapsicle.io/en/swap",
     "social": {
       "discord": "https://discord.com/invite/swapsicle",
-      "twitter": "https://twitter.com/SwapsicleDEX"
+      "twitter": "https://x.com/SwapsicleDEX"
     }
   },
   "singular": {
@@ -367,7 +367,7 @@
     "website": "https://singular.farm/",
     "social": {
       "telegram": "https://t.me/singularfarm",
-      "twitter": "https://twitter.com/singularfarm"
+      "twitter": "https://x.com/singularfarm"
     }
   },
   "beefy": {
@@ -376,7 +376,7 @@
     "website": "https://app.beefy.finance",
     "social": {
       "telegram": "http://t.me/beefyfinance",
-      "twitter": "https://twitter.com/beefyfinance"
+      "twitter": "https://x.com/beefyfinance"
     }
   },
   "grape": {
@@ -385,7 +385,7 @@
     "website": "https://grapefinance.app/",
     "social": {
       "discord": "https://discord.gg/mZ4QrZwH5M",
-      "twitter": "https://twitter.com/grape_finance"
+      "twitter": "https://x.com/grape_finance"
     }
   },
   "ripae": {
@@ -394,7 +394,7 @@
     "website": "https://ripae.finance/",
     "social": {
       "discord": "https://discord.gg/6zq53FB4TS",
-      "twitter": "https://twitter.com/ripaefinance"
+      "twitter": "https://x.com/ripaefinance"
     }
   },
   "nitro": {
@@ -412,7 +412,7 @@
     "website": "https://home.babyswap.finance/",
     "social": {
       "telegram": "https://t.me/baby_swap",
-      "twitter": "https://twitter.com/babyswap_bsc"
+      "twitter": "https://x.com/babyswap_bsc"
     }
   },
   "bitcrush": {
@@ -421,7 +421,7 @@
     "website": "https://www.bitcrush.com/",
     "social": {
       "telegram": "https://t.me/Bcarcadechat",
-      "twitter": "https://twitter.com/bitcrusharcade"
+      "twitter": "https://x.com/bitcrusharcade"
     }
   },
   "nfty": {
@@ -430,7 +430,7 @@
     "website": "https://nftynetwork.io/",
     "social": {
       "telegram": "https://t.me/NFTYNetwork",
-      "twitter": "https://twitter.com/NFTYNetwork"
+      "twitter": "https://x.com/NFTYNetwork"
     }
   },
   "charge": {
@@ -439,7 +439,7 @@
     "website": "https://bit.ly/32NB1tP",
     "social": {
       "telegram": "https://t.me/chargedefi",
-      "twitter": "https://twitter.com/ChargeDeFi"
+      "twitter": "https://x.com/ChargeDeFi"
     }
   },
   "mogul": {
@@ -448,7 +448,7 @@
     "website": "https://www.mogulproductions.com/",
     "social": {
       "telegram": "https://t.me/mogulproductions",
-      "twitter": "https://twitter.com/mogulofficial_"
+      "twitter": "https://x.com/mogulofficial_"
     }
   },
   "blockmine": {
@@ -457,7 +457,7 @@
     "website": "https://block-mine.io/",
     "social": {
       "telegram": "https://t.me/blockmine_io",
-      "twitter": "https://twitter.com/blockmine_io"
+      "twitter": "https://x.com/blockmine_io"
     }
   },
   "bishares": {
@@ -466,7 +466,7 @@
     "website": "https://bishares.finance/",
     "social": {
       "telegram": "https://t.me/bishares",
-      "twitter": "https://twitter.com/BiSharesFinance"
+      "twitter": "https://x.com/BiSharesFinance"
     }
   },
   "betu": {
@@ -475,7 +475,7 @@
     "website": "https://betu.io/",
     "social": {
       "telegram": "https://t.me/betucommunity",
-      "twitter": "https://twitter.com/betuglobal"
+      "twitter": "https://x.com/betuglobal"
     }
   },
   "oasis": {
@@ -484,7 +484,7 @@
     "website": "https://projectoasis.io/",
     "social": {
       "telegram": "https://t.me/projectoasis_official",
-      "twitter": "https://twitter.com/ProjectOasis_"
+      "twitter": "https://x.com/ProjectOasis_"
     }
   },
   "ceek": {
@@ -493,7 +493,7 @@
     "website": "https://www.ceek.io/",
     "social": {
       "telegram": "https://t.me/ceekvrtokensale",
-      "twitter": "https://twitter.com/ceek"
+      "twitter": "https://x.com/ceek"
     }
   },
   "gamexchange": {
@@ -502,7 +502,7 @@
     "website": "https://gamexchange.app/",
     "social": {
       "telegram": "https://t.me/GameXChange",
-      "twitter": "https://twitter.com/GameX_Change"
+      "twitter": "https://x.com/GameX_Change"
     }
   },
   "wsg": {
@@ -511,7 +511,7 @@
     "website": "https://stake.wallstreetgames.net/",
     "social": {
       "telegram": "https://t.me/WSGToken",
-      "twitter": "https://twitter.com/WSGToken"
+      "twitter": "https://x.com/WSGToken"
     }
   },
   "dep": {
@@ -520,7 +520,7 @@
     "website": "https://playmining.com/?locale=en",
     "social": {
       "telegram": "https://t.me/DEAPcoin_group",
-      "twitter": "https://twitter.com/PlayMining_SG"
+      "twitter": "https://x.com/PlayMining_SG"
     }
   },
   "cafeswap": {
@@ -529,7 +529,7 @@
     "website": "https://cafeswap.finance",
     "social": {
       "telegram": "https://t.me/CafeSwap",
-      "twitter": "https://twitter.com/cafeswapfinance"
+      "twitter": "https://x.com/cafeswapfinance"
     }
   },
   "pacoca": {
@@ -538,7 +538,7 @@
     "website": "https://pacoca.io/",
     "social": {
       "telegram": "https://t.me/pacoca_io",
-      "twitter": "https://twitter.com/pacoca_io"
+      "twitter": "https://x.com/pacoca_io"
     }
   },
   "annex": {
@@ -547,7 +547,7 @@
     "website": "https://annex.finance/",
     "social": {
       "telegram": "https://t.me/Annex_finance_group",
-      "twitter": "https://twitter.com/AnnexFinance"
+      "twitter": "https://x.com/AnnexFinance"
     }
   },
   "pearzap": {
@@ -556,7 +556,7 @@
     "website": "https://pearzap.com/",
     "social": {
       "telegram": "https://t.me/pearzap",
-      "twitter": "https://twitter.com/pearzap"
+      "twitter": "https://x.com/pearzap"
     }
   },
   "czodiac": {
@@ -565,7 +565,7 @@
     "website": "https://app.czodiac.com/",
     "social": {
       "telegram": "https://t.me/CZodiacofficial",
-      "twitter": "https://twitter.com/zodiacs_c"
+      "twitter": "https://x.com/zodiacs_c"
     }
   },
   "longdrink": {
@@ -574,7 +574,7 @@
     "website": "https://longdrink.finance/",
     "social": {
       "telegram": "https://t.me/longdrinkfinance",
-      "twitter": "https://twitter.com/LongdrinkDefi"
+      "twitter": "https://x.com/LongdrinkDefi"
     }
   },
   "honey": {
@@ -583,7 +583,7 @@
     "website": "https://honeyfarm.finance/",
     "social": {
       "telegram": "https://t.me/HoneyFarmChat",
-      "twitter": "https://twitter.com/HoneyFarmFi"
+      "twitter": "https://x.com/HoneyFarmFi"
     }
   },
   "moonpot": {
@@ -592,7 +592,7 @@
     "website": "https://moonpot.com/",
     "social": {
       "telegram": "https://t.me/moonpotdotcom",
-      "twitter": "https://twitter.com/moonpotdotcom"
+      "twitter": "https://x.com/moonpotdotcom"
     }
   },
   "viralata": {
@@ -610,7 +610,7 @@
     "website": "https://elk.finance/",
     "social": {
       "telegram": "https://t.me/elk_finance",
-      "twitter": "https://twitter.com/elk_finance"
+      "twitter": "https://x.com/elk_finance"
     }
   },
   "omnifarm": {
@@ -619,7 +619,7 @@
     "website": "https://omnitrade.ocp.finance/",
     "social": {
       "telegram": "http://t.me/opendao",
-      "twitter": "https://twitter.com/opendaoprotocol"
+      "twitter": "https://x.com/opendaoprotocol"
     }
   },
   "tosdis": {
@@ -628,7 +628,7 @@
     "website": "https://app.tosdis.finance/stake",
     "social": {
       "telegram": "https://t.me/Tosdis",
-      "twitter": "https://twitter.com/TosdisFinance"
+      "twitter": "https://x.com/TosdisFinance"
     }
   },
   "yel": {
@@ -637,7 +637,7 @@
     "website": "https://yel.finance/",
     "social": {
       "telegram": "https://t.me/yelfinance",
-      "twitter": "https://twitter.com/yel_finance"
+      "twitter": "https://x.com/yel_finance"
     }
   },
   "billionhappiness": {
@@ -646,7 +646,7 @@
     "website": "https://billionhappiness.finance",
     "social": {
       "telegram": "https://t.me/BillionHappinessOfficial",
-      "twitter": "https://twitter.com/BHC_Happiness"
+      "twitter": "https://x.com/BHC_Happiness"
     }
   },
   "ternoa": {
@@ -655,7 +655,7 @@
     "website": "https://www.ternoa.com/en",
     "social": {
       "telegram": "https://t.me/ternoa",
-      "twitter": "https://twitter.com/ternoa_"
+      "twitter": "https://x.com/ternoa_"
     }
   },
   "wolfden": {
@@ -664,7 +664,7 @@
     "website": "https://www.wolfdencrypto.com/",
     "social": {
       "telegram": "https://t.me/wolfdencrypto",
-      "twitter": "https://twitter.com/wolfdencrypto"
+      "twitter": "https://x.com/wolfdencrypto"
     }
   },
   "landshare": {
@@ -673,7 +673,7 @@
     "website": "https://landshare.io/",
     "social": {
       "telegram": "https://t.me/landshare",
-      "twitter": "https://twitter.com/landshareio"
+      "twitter": "https://x.com/landshareio"
     }
   },
   "pera": {
@@ -682,7 +682,7 @@
     "website": "https://pera.finance/",
     "social": {
       "telegram": "https://t.me/perafinance",
-      "twitter": "https://twitter.com/perafinance"
+      "twitter": "https://x.com/perafinance"
     }
   },
   "farmhero": {
@@ -691,7 +691,7 @@
     "website": "https://farmhero.io/",
     "social": {
       "telegram": "https://t.me/farmheroIO",
-      "twitter": "https://twitter.com/FarmHeroIO"
+      "twitter": "https://x.com/FarmHeroIO"
     }
   },
   "fruit": {
@@ -700,7 +700,7 @@
     "website": "https://www.fruitsadventures.com",
     "social": {
       "telegram": "https://t.me/fruitsadventures_com",
-      "twitter": "https://twitter.com/FruitsAdventure"
+      "twitter": "https://x.com/FruitsAdventure"
     }
   },
   "krown": {
@@ -709,7 +709,7 @@
     "website": "https://kingdefi.io/",
     "social": {
       "telegram": "https://t.me/KingDefi_Community",
-      "twitter": "https://twitter.com/KingDefi2"
+      "twitter": "https://x.com/KingDefi2"
     }
   },
   "merlin": {
@@ -718,7 +718,7 @@
     "website": "https://merlinlab.com/farm",
     "social": {
       "telegram": "https://t.me/merlinlab",
-      "twitter": "https://twitter.com/MerlinLab_"
+      "twitter": "https://x.com/MerlinLab_"
     }
   },
   "tenfi": {
@@ -727,7 +727,7 @@
     "website": "https://ten.finance",
     "social": {
       "telegram": "https://t.me/tenfinance",
-      "twitter": "https://twitter.com/tenfinance"
+      "twitter": "https://x.com/tenfinance"
     }
   },
   "panther": {
@@ -736,7 +736,7 @@
     "website": "https://pantherswap.com/",
     "social": {
       "telegram": "https://t.me/PantherSwap",
-      "twitter": "https://twitter.com/PantherSwap"
+      "twitter": "https://x.com/PantherSwap"
     }
   },
   "dopple": {
@@ -745,7 +745,7 @@
     "website": "https://dopple.finance/Swap",
     "social": {
       "telegram": "https://t.me/dopplefi",
-      "twitter": "https://twitter.com/dopplefi"
+      "twitter": "https://x.com/dopplefi"
     }
   },
   "jetswap": {
@@ -754,7 +754,7 @@
     "website": "https://jetswap.finance/",
     "social": {
       "telegram": "https://t.me/jetfuelfinance",
-      "twitter": "https://twitter.com/Jetfuelfinance"
+      "twitter": "https://x.com/Jetfuelfinance"
     }
   },
   "dumpling": {
@@ -763,7 +763,7 @@
     "website": "https://app.dumplingdefi.finance/",
     "social": {
       "telegram": "https://t.me/dumplingswap_official",
-      "twitter": "https://twitter.com/dumpling_swap"
+      "twitter": "https://x.com/dumpling_swap"
     }
   },
   "grandbanks": {
@@ -772,7 +772,7 @@
     "website": "https://www.thegrandbanks.finance/#/",
     "social": {
       "telegram": "https://t.me/theGrandBanks",
-      "twitter": "https://twitter.com/Grandbanks13"
+      "twitter": "https://x.com/Grandbanks13"
     }
   },
   "ironfinance": {
@@ -781,7 +781,7 @@
     "website": "https://app.iron.finance/",
     "social": {
       "telegram": "https://t.me/ironfinance",
-      "twitter": "https://twitter.com/IronFinance"
+      "twitter": "https://x.com/IronFinance"
     }
   },
   "safefarm": {
@@ -790,7 +790,7 @@
     "website": "https://safefarms.marshmallowdefi.com/info",
     "social": {
       "telegram": "https://t.me/MarshmallowDeFi",
-      "twitter": "https://twitter.com/SwapMarshmallow"
+      "twitter": "https://x.com/SwapMarshmallow"
     }
   },
   "xbtc": {
@@ -799,7 +799,7 @@
     "website": "https://xbtc.fi/",
     "social": {
       "telegram": "https://t.me/xBTC_Official",
-      "twitter": "https://twitter.com/XBTC_Official"
+      "twitter": "https://x.com/XBTC_Official"
     }
   },
   "icarus": {
@@ -808,7 +808,7 @@
     "website": "http://icarus.finance",
     "social": {
       "telegram": "https://t.me/icarus_finance",
-      "twitter": "https://twitter.com/zetta_icarus"
+      "twitter": "https://x.com/zetta_icarus"
     }
   },
   "satis": {
@@ -817,7 +817,7 @@
     "website": "https://satis.finance/",
     "social": {
       "telegram": "https://t.me/satisfiChat",
-      "twitter": "https://twitter.com/FinanceSatis"
+      "twitter": "https://x.com/FinanceSatis"
     }
   },
   "apyswap": {
@@ -826,7 +826,7 @@
     "website": "https://apyswap.com/",
     "social": {
       "telegram": "https://t.me/apyswapcom",
-      "twitter": "https://twitter.com/apyswap"
+      "twitter": "https://x.com/apyswap"
     }
   },
   "mash": {
@@ -835,7 +835,7 @@
     "website": "https://marshmallowdefi.com/",
     "social": {
       "telegram": "https://t.me/MarshmallowDeFi",
-      "twitter": "https://twitter.com/SwapMarshmallow"
+      "twitter": "https://x.com/SwapMarshmallow"
     }
   },
   "yieldbay": {
@@ -844,7 +844,7 @@
     "website": "https://yieldbay.finance/",
     "social": {
       "telegram": "https://t.me/yieldbay",
-      "twitter": "https://twitter.com/yieldbay"
+      "twitter": "https://x.com/yieldbay"
     }
   },
   "thypoon": {
@@ -853,7 +853,7 @@
     "website": "https://app.typhoon.network/",
     "social": {
       "telegram": "https://t.me/typhoonnetwork",
-      "twitter": "https://twitter.com/TyphoonCrypto"
+      "twitter": "https://x.com/TyphoonCrypto"
     }
   },
   "biticity": {
@@ -862,7 +862,7 @@
     "website": "https://www.biti.city",
     "social": {
       "telegram": "https://t.me/biti_city",
-      "twitter": "https://twitter.com/bitibots"
+      "twitter": "https://x.com/bitibots"
     }
   },
   "bingo": {
@@ -871,7 +871,7 @@
     "website": "https://bingocash.fi/",
     "social": {
       "telegram": "https://t.me/bingocash_official",
-      "twitter": "https://twitter.com/Bingocashfi"
+      "twitter": "https://x.com/Bingocashfi"
     }
   },
   "thunder": {
@@ -880,7 +880,7 @@
     "website": "https://thunderswap.finance/",
     "social": {
       "telegram": "https://t.me/thunder_swap",
-      "twitter": "https://twitter.com/thunder_swap"
+      "twitter": "https://x.com/thunder_swap"
     }
   },
   "swirl": {
@@ -889,7 +889,7 @@
     "website": "https://swirl.cash/",
     "social": {
       "telegram": "https://t.me/Swirl_Cash",
-      "twitter": "https://twitter.com/Swirl_Cash"
+      "twitter": "https://x.com/Swirl_Cash"
     }
   },
   "zcore": {
@@ -898,7 +898,7 @@
     "website": "https://finance.zcore.network/",
     "social": {
       "telegram": "https://t.me/ZCoreMiners",
-      "twitter": "https://twitter.com/ZCoreCrypto"
+      "twitter": "https://x.com/ZCoreCrypto"
     }
   },
   "astronaut": {
@@ -907,7 +907,7 @@
     "website": "https://astronaut.to/",
     "social": {
       "telegram": "https://t.me/joinchat/pJTzEu-mhnAzMjMx",
-      "twitter": "https://twitter.com/astronauttoken"
+      "twitter": "https://x.com/astronauttoken"
     }
   },
   "space": {
@@ -916,7 +916,7 @@
     "website": "https://farm.space/",
     "social": {
       "telegram": "https://t.me/farmdotspace",
-      "twitter": "https://twitter.com/farmdotspace"
+      "twitter": "https://x.com/farmdotspace"
     }
   },
   "squirrel": {
@@ -925,7 +925,7 @@
     "website": "https://squirrel.finance/",
     "social": {
       "telegram": "https://t.me/SquirrelDeFi",
-      "twitter": "https://twitter.com/SquirrelDeFi"
+      "twitter": "https://x.com/SquirrelDeFi"
     }
   },
   "memefarm": {
@@ -934,7 +934,7 @@
     "website": "https://memefarm.io/",
     "social": {
       "telegram": "https://t.me/APEcoin_Chat",
-      "twitter": "https://twitter.com/Go_MemeFarm"
+      "twitter": "https://x.com/Go_MemeFarm"
     }
   },
   "slimefinance": {
@@ -943,7 +943,7 @@
     "website": "https://slime.finance/",
     "social": {
       "telegram": "https://t.me/slimefinance",
-      "twitter": "https://twitter.com/slimefinance"
+      "twitter": "https://x.com/slimefinance"
     }
   },
   "ramenswap": {
@@ -952,7 +952,7 @@
     "website": "https://ramenswap.finance/",
     "social": {
       "telegram": "https://t.me/ramenswap",
-      "twitter": "https://twitter.com/ramenswap"
+      "twitter": "https://x.com/ramenswap"
     }
   },
   "saltswap": {
@@ -961,7 +961,7 @@
     "website": "https://saltswap.finance/",
     "social": {
       "telegram": "https://t.me/saltswap",
-      "twitter": "https://twitter.com/saltswap"
+      "twitter": "https://x.com/saltswap"
     }
   },
   "crowfinance": {
@@ -970,7 +970,7 @@
     "website": "https://www.crowfinance.net/",
     "social": {
       "telegram": "https://t.me/CrowFinance",
-      "twitter": "https://twitter.com/crowfinance"
+      "twitter": "https://x.com/crowfinance"
     }
   },
   "apeswap": {
@@ -979,7 +979,7 @@
     "website": "https://apeswap.finance/",
     "social": {
       "telegram": "https://t.me/ape_swap",
-      "twitter": "https://twitter.com/ape_swap"
+      "twitter": "https://x.com/ape_swap"
     }
   },
   "soup": {
@@ -988,7 +988,7 @@
     "website": "https://soups.finance/",
     "social": {
       "telegram": "https://t.me/soup_community",
-      "twitter": "https://twitter.com/soupingGood"
+      "twitter": "https://x.com/soupingGood"
     }
   },
   "tanks": {
@@ -997,7 +997,7 @@
     "website": "https://ageoftanks.io/",
     "social": {
       "telegram": "https://t.me/ageoftanksdiscussion",
-      "twitter": "https://twitter.com/AgeOfTanksNFT?s=09"
+      "twitter": "https://x.com/AgeOfTanksNFT?s=09"
     }
   },
   "dibs": {
@@ -1006,7 +1006,7 @@
     "website": "https://www.dibs.money/farm",
     "social": {
       "telegram": "https://t.me/dibsmoney",
-      "twitter": "https://twitter.com/DibsMoney"
+      "twitter": "https://x.com/DibsMoney"
     }
   },
   "empmoney": {
@@ -1015,7 +1015,7 @@
     "website": "https://emp.money/",
     "social": {
       "telegram": "https://t.me/empmoney",
-      "twitter": "https://twitter.com/empmoneybsc"
+      "twitter": "https://x.com/empmoneybsc"
     }
   },
   "biswap": {
@@ -1024,7 +1024,7 @@
     "website": "https://biswap.org/farms",
     "social": {
       "telegram": "https://t.me/biswap",
-      "twitter": "https://twitter.com/Biswap_DEX"
+      "twitter": "https://x.com/Biswap_DEX"
     }
   },
   "bombmoney": {
@@ -1033,7 +1033,7 @@
     "website": "https://www.bomb.money/",
     "social": {
       "telegram": "https://t.me/bombmoneybsc",
-      "twitter": "https://twitter.com/BombMoneyBSC"
+      "twitter": "https://x.com/BombMoneyBSC"
     }
   },
   "liquidus": {
@@ -1042,7 +1042,7 @@
     "website": "https://farm.liquidus.finance/",
     "social": {
       "telegram": "https://t.me/liquidusfinance",
-      "twitter": "https://twitter.com/LiquidusFinance"
+      "twitter": "https://x.com/LiquidusFinance"
     }
   },
   "dark": {
@@ -1051,7 +1051,7 @@
     "website": "https://www.darkcrypto.finance/",
     "social": {
       "telegram": "https://t.me/darkcryptofi",
-      "twitter": "https://twitter.com/DarkCryptoFi"
+      "twitter": "https://x.com/DarkCryptoFi"
     }
   },
   "valleyswap": {
@@ -1060,7 +1060,7 @@
     "website": "https://valleyswap.com/",
     "social": {
       "telegram": "https://t.me/valleyswap_chat",
-      "twitter": "https://twitter.com/ValleySwap"
+      "twitter": "https://x.com/ValleySwap"
     }
   },
   "scream": {
@@ -1069,7 +1069,7 @@
     "website": "https://scream.sh/",
     "social": {
       "telegram": "https://t.me/screamsh",
-      "twitter": "https://twitter.com/screamdotsh"
+      "twitter": "https://x.com/screamdotsh"
     }
   },
   "tombfinance": {
@@ -1078,7 +1078,7 @@
     "website": "https://tomb.finance",
     "social": {
       "telegram": "https://t.me/tombfinance",
-      "twitter": "https://twitter.com/tombfinance"
+      "twitter": "https://x.com/tombfinance"
     }
   },
   "esterfinance": {
@@ -1086,7 +1086,7 @@
     "text": "Ester.Finance is a Decentralized Finance (DeFi) Yield Optimizer project on the Fantom Opera Blockchain. Ester can make you earn more crypto with crypto. Through a set of smart contracts and several investment strategies, Ester.Finance automatically maximizes the user rewards from various liquidity pools (LPs), automated market-making (AMM) projects, and other yield farming opportunities in the DeFi ecosystem. This provides a huge advantage over attempting to do this manually yourself.",
     "website": "https://app.ester.finance/",
     "social": {
-      "twitter": "https://twitter.com/EsterFinance"
+      "twitter": "https://x.com/EsterFinance"
     }
   },
   "2omb": {
@@ -1095,7 +1095,7 @@
     "website": "https://2omb.finance/",
     "social": {
       "discord": "https://discord.gg/sTXFJ82HcP",
-      "twitter": "https://twitter.com/2ombfinance"
+      "twitter": "https://x.com/2ombfinance"
     }
   },
   "spirit": {
@@ -1104,7 +1104,7 @@
     "website": "https://app.spiritswap.finance/",
     "social": {
       "discord": "https://discord.gg/spiritswap",
-      "twitter": "https://twitter.com/Spirit_Swap"
+      "twitter": "https://x.com/Spirit_Swap"
     }
   },
   "wigoswap": {
@@ -1113,7 +1113,7 @@
     "website": "https://wigoswap.io/",
     "social": {
       "telegram": "https://t.me/wigoswap",
-      "twitter": "https://twitter.com/wigoswap"
+      "twitter": "https://x.com/wigoswap"
     }
   },
   "based": {
@@ -1122,7 +1122,7 @@
     "website": "https://basedfinance.io/",
     "social": {
       "telegram": "https://t.me/BasedFinanceio",
-      "twitter": "https://twitter.com/BasedFinance_io"
+      "twitter": "https://x.com/BasedFinance_io"
     }
   },
   "orkan": {
@@ -1131,7 +1131,7 @@
     "website": "https://orkan.finance/#/dashboard",
     "social": {
       "discord": "https://discord.com/invite/mqd2ZaXeEB",
-      "twitter": "https://twitter.com/EnterTheStrudel"
+      "twitter": "https://x.com/EnterTheStrudel"
     }
   },
   "hector": {
@@ -1140,7 +1140,7 @@
     "website": "https://app.hector.finance/#/farming",
     "social": {
       "telegram": "https://t.me/hectorDAO",
-      "twitter": "https://twitter.com/HectorDAO_HEC"
+      "twitter": "https://x.com/HectorDAO_HEC"
     }
   },
   "midas": {
@@ -1149,7 +1149,7 @@
     "website": "https://midas.investments/",
     "social": {
       "telegram": "https://t.co/9VgNoIRTDb",
-      "twitter": "https://twitter.com/Midas_platform"
+      "twitter": "https://x.com/Midas_platform"
     }
   },
   "fuse": {
@@ -1158,7 +1158,7 @@
     "website": "https://www.fuse.io",
     "social": {
       "telegram": "https://t.me/fuseio",
-      "twitter": "https://twitter.com/Fuse_network"
+      "twitter": "https://x.com/Fuse_network"
     }
   },
   "elon": {
@@ -1167,7 +1167,7 @@
     "website": "https://dogelonmars.com/",
     "social": {
       "telegram": "https://t.me/dogelonmars",
-      "twitter": "https://twitter.com/DogelonMars"
+      "twitter": "https://x.com/DogelonMars"
     }
   },
   "relay": {
@@ -1176,7 +1176,7 @@
     "website": "https://app.relaychain.com/#/cross-chain-bridge-transfer",
     "social": {
       "telegram": "https://t.me/relaychaincommunity",
-      "twitter": "https://twitter.com/relay_chain"
+      "twitter": "https://x.com/relay_chain"
     }
   },
   "stellaswap": {
@@ -1194,7 +1194,7 @@
     "website": "https://www.huckleberry.finance/",
     "social": {
       "telegram": "https://t.me/HuckleberryDex",
-      "twitter": "https://twitter.com/HuckleberryDEX"
+      "twitter": "https://x.com/HuckleberryDEX"
     }
   },
   "jarvis": {
@@ -1203,7 +1203,7 @@
     "website": "https://jarvis.network/",
     "social": {
       "telegram": "https://t.me/jarvisnetwork",
-      "twitter": "https://twitter.com/jarvis_network"
+      "twitter": "https://x.com/jarvis_network"
     }
   },
   "polysage": {
@@ -1212,7 +1212,7 @@
     "website": "https://polysage.finance/",
     "social": {
       "telegram": "https://t.me/polywisedefi",
-      "twitter": "https://twitter.com/polywisefinance"
+      "twitter": "https://x.com/polywisefinance"
     }
   },
   "tetu": {
@@ -1221,7 +1221,7 @@
     "website": "https://app.tetu.io/",
     "social": {
       "telegram": "https://t.me/tetu_io",
-      "twitter": "https://twitter.com/tetu_io"
+      "twitter": "https://x.com/tetu_io"
     }
   },
   "polywise": {
@@ -1230,7 +1230,7 @@
     "website": "https://polywise.finance/",
     "social": {
       "telegram": "https://t.me/polywisedefi",
-      "twitter": "https://twitter.com/polywisefinance"
+      "twitter": "https://x.com/polywisefinance"
     }
   },
   "polyalpha": {
@@ -1239,7 +1239,7 @@
     "website": "https://polyalpha.finance/",
     "social": {
       "telegram": "https://t.me/PolyAlphaFi",
-      "twitter": "https://twitter.com/PolyAlphaFi"
+      "twitter": "https://x.com/PolyAlphaFi"
     }
   },
   "sandman": {
@@ -1248,7 +1248,7 @@
     "website": "https://sandman.finance/",
     "social": {
       "telegram": "https://t.me/SandMan_Finance",
-      "twitter": "https://twitter.com/sandman_finance"
+      "twitter": "https://x.com/sandman_finance"
     }
   },
   "yieldwatch": {
@@ -1257,7 +1257,7 @@
     "website": "https://www.yieldwatch.net/",
     "social": {
       "telegram": "https://t.me/yieldwatch",
-      "twitter": "https://twitter.com/yieldwatch"
+      "twitter": "https://x.com/yieldwatch"
     }
   },
   "polypup": {
@@ -1266,7 +1266,7 @@
     "website": "https://bone.polypup.finance/",
     "social": {
       "telegram": "https://t.me/PolyPupFarm",
-      "twitter": "https://twitter.com/PolyPup1"
+      "twitter": "https://x.com/PolyPup1"
     }
   },
   "polyfarm": {
@@ -1275,7 +1275,7 @@
     "website": "https://polygonfarm.finance/",
     "social": {
       "telegram": "https://t.me/PolygonFarmFinance",
-      "twitter": "https://twitter.com/PolygonFarmFi"
+      "twitter": "https://x.com/PolygonFarmFi"
     }
   },
   "polycracker": {
@@ -1284,7 +1284,7 @@
     "website": "https://polywantsacracker.farm/",
     "social": {
       "telegram": "https://t.me/PolyWantsACracker_Farm",
-      "twitter": "https://twitter.com/PolyWantsAFarm"
+      "twitter": "https://x.com/PolyWantsAFarm"
     }
   },
   "xyeld": {
@@ -1293,7 +1293,7 @@
     "website": "https://layer.polyyeld.finance/",
     "social": {
       "telegram": "https://t.me/polyyeld",
-      "twitter": "https://twitter.com/PolyYeldFinance"
+      "twitter": "https://x.com/PolyYeldFinance"
     }
   },
   "qidao": {
@@ -1302,7 +1302,7 @@
     "website": "https://www.mai.finance/",
     "social": {
       "telegram": "https://t.me/QiDaoProtocol",
-      "twitter": "https://twitter.com/QiDaoProtocol"
+      "twitter": "https://x.com/QiDaoProtocol"
     }
   },
   "boneswap": {
@@ -1311,7 +1311,7 @@
     "website": "https://farm.boneswap.finance",
     "social": {
       "telegram": "https://t.me/boneswapfi",
-      "twitter": "https://twitter.com/boneswapfi"
+      "twitter": "https://x.com/boneswapfi"
     }
   },
   "polyyeld": {
@@ -1321,7 +1321,7 @@
     "social": {
       "telegram": "https://t.me/polyyeld",
       "discord": "https://discord.gg/8nK8aQqnCc",
-      "twitter": "https://twitter.com/PolyYeldFinance"
+      "twitter": "https://x.com/PolyYeldFinance"
     }
   },
   "garuda": {
@@ -1330,7 +1330,7 @@
     "website": "https://garudaswap.finance/",
     "social": {
       "telegram": "https://t.me/garudaswap",
-      "twitter": "https://twitter.com/GarudaSwap"
+      "twitter": "https://x.com/GarudaSwap"
     }
   },
   "fanatics": {
@@ -1339,7 +1339,7 @@
     "website": "https://fanaticsfinance.com/",
     "social": {
       "telegram": "https://t.me/fanaticsfinance_EN",
-      "twitter": "https://twitter.com/fanaticsfinance"
+      "twitter": "https://x.com/fanaticsfinance"
     }
   },
   "lido": {
@@ -1348,7 +1348,7 @@
     "website": "https://polygon.lido.fi/",
     "social": {
       "discord": "https://discord.com/invite/vgdPfhZ",
-      "twitter": "https://twitter.com/LidoOnPolygon"
+      "twitter": "https://x.com/LidoOnPolygon"
     }
   },
   "lido-moonriver": {
@@ -1357,7 +1357,7 @@
     "website": "https://kusama.lido.fi/",
     "social": {
       "discord": "https://discord.com/invite/FwG5QFWvfn",
-      "twitter": "https://twitter.com/lidofinance"
+      "twitter": "https://x.com/lidofinance"
     }
   },
   "lido-moonbeam": {
@@ -1366,7 +1366,7 @@
     "website": "https://polkadot.lido.fi/",
     "social": {
       "discord": "https://discord.com/invite/vgdPfhZ",
-      "twitter": "https://twitter.com/lidofinance"
+      "twitter": "https://x.com/lidofinance"
     }
   },
   "lido-eth": {
@@ -1375,7 +1375,7 @@
     "website": "https://lido.fi/",
     "social": {
       "discord": "https://discord.com/invite/lido",
-      "twitter": "https://twitter.com/lidofinance"
+      "twitter": "https://x.com/lidofinance"
     }
   },
   "mountain": {

--- a/src/features/vault/components/ShareButton/ShareButton.tsx
+++ b/src/features/vault/components/ShareButton/ShareButton.tsx
@@ -184,7 +184,7 @@ const TwitterItem = memo<ShareServiceItemProps>(function TwitterItem({ details }
       url: details.vaultUrl,
     });
 
-    window.open(`https://twitter.com/intent/tweet?${params}`, '_blank');
+    window.open(`https://x.com/intent/tweet?${params}`, '_blank');
   }, [details, t]);
 
   return <ShareItem text={t('Vault-Share-Twitter')} onClick={onClick} icon={twitterIcon} />;


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.
These changes ensure better readability and accurate terminology in the documentation. Feel free to reach out if further assistance is needed.
