### PR TITLE
Add ability to pin any vault

### DIFF
--- a/src/config/boost/arbitrum.json
+++ b/src/config/boost/arbitrum.json
@@ -16,8 +16,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "renzo-lido",
-    "partners": ["renzo", "lido-eth"],
-    "pinned": false
+    "partners": ["renzo", "lido-eth"]
   },
   {
     "id": "moo_stargate-v2-arb-weth",
@@ -37,8 +36,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_compound-arbitrum-usdc",
@@ -58,8 +56,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_silo-arb-silo",
@@ -79,8 +76,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_sushi-cow-arb-usdc-usdt-vault",
@@ -100,8 +96,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-usdc-usd+-vault",
@@ -121,8 +116,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-usd+-usdt-vault",
@@ -142,8 +136,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-weth-usd+-500-vault",
@@ -163,8 +156,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-weth-usd+-100-vault",
@@ -184,8 +176,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_sushi-cow-arb-zro-weth-vault",
@@ -205,8 +196,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_sushi-cow-arb-weth-arb-500-vault",
@@ -226,8 +216,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_sushi-cow-arb-weth-usdc-vault",
@@ -247,8 +236,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_sushi-cow-arb-wbtc-tbtc-vault",
@@ -268,8 +256,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_sushi-cow-arb-wsteth-weth-vault",
@@ -289,8 +276,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_ramses-cl-rseth-ethx-vault",
@@ -310,8 +296,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_sushi-cow-arb-usdt-usdc.e-vault",
@@ -331,8 +316,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_sushi-cow-arb-wbtc-usdc-vault",
@@ -352,8 +336,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_sushi-cow-arb-arb-usdc-vault",
@@ -373,8 +356,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_sushi-cow-arb-usdc-usdc.e-vault",
@@ -394,8 +376,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_sushi-cow-arb-weth-usdc-100-vault",
@@ -415,8 +396,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_pancake-cow-arb-weth-usdt-500-vault",
@@ -436,8 +416,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_pancake-cow-arb-weth-usdc-500-vault",
@@ -457,8 +436,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_pancake-cow-arb-wbtc-usdc-vault",
@@ -478,8 +456,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_pancake-cow-arb-arb-usdc-vault",
@@ -499,8 +476,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_pancake-cow-arb-zro-weth-vault",
@@ -520,8 +496,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_pancake-cow-arb-weth-usd+-vault",
@@ -541,8 +516,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_pancake-cow-arb-weth-reth-vault",
@@ -562,8 +536,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_pancake-cow-arb-wsteth-weth-vault",
@@ -583,8 +556,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_pancake-cow-arb-wbtc-weth-vault",
@@ -604,8 +576,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_pancake-cow-arb-usdc-usdt-vault",
@@ -625,8 +596,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_pancake-cow-arb-cake-weth-vault",
@@ -646,8 +616,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aura-arb-ezeth-wsteth-lido",
@@ -701,8 +670,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_ramses-cl-rseth-weth-vault",
@@ -722,8 +690,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-rseth-weth-vault",
@@ -743,8 +710,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_curve-arb-usdc-usdm-mountain",
@@ -761,8 +727,7 @@
     "partnership": true,
     "status": "active",
     "isMooStaked": true,
-    "partners": ["mountain"],
-    "pinned": false
+    "partners": ["mountain"]
   },
   {
     "id": "moo_uniswap-cow-arb-rseth-wsteth-vault",
@@ -782,8 +747,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-usdc-usdt-vault",
@@ -803,8 +767,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-usdv-usdc-vault",
@@ -824,8 +787,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-comp-weth-vault",
@@ -845,8 +807,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-usdc-aave-vault",
@@ -866,8 +827,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-ldo-usdc-vault",
@@ -887,8 +847,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-uni-usdt-vault",
@@ -908,8 +867,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-usdc-uni-vault",
@@ -929,8 +887,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-wbtc-link-vault",
@@ -950,8 +907,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-link-usdt-vault",
@@ -971,8 +927,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-usde-usdt-vault",
@@ -992,8 +947,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-frax-usdt-vault",
@@ -1013,8 +967,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-crv-weth-vault",
@@ -1034,8 +987,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-cbeth-weth-vault",
@@ -1055,8 +1007,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-weth-rpl-vault",
@@ -1076,8 +1027,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-weth-reth-vault",
@@ -1097,8 +1047,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-pepe-weth-vault",
@@ -1118,8 +1067,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-wsteth-usdc-vault",
@@ -1139,8 +1087,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-tbtc-weth-prod-vault",
@@ -1160,8 +1107,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-wbtc-tbtc-vault",
@@ -1181,8 +1127,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-wusdm-wsteth-vault",
@@ -1202,8 +1147,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_ramses-zero-weth-vault",
@@ -1223,8 +1167,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_ramses-cl-weth-usdc-vault",
@@ -1244,8 +1187,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_ramses-cl-arb-usdc-vault",
@@ -1265,8 +1207,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_ramses-ethfi-weth-vault",
@@ -1286,8 +1227,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_ramses-cl-wbtc-weth-vault",
@@ -1307,8 +1247,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-weth-uni-vault",
@@ -1328,8 +1267,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-weth-dai-vault",
@@ -1349,8 +1287,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-wsteth-weth-vault",
@@ -1370,8 +1307,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-eusd-usdc-vault",
@@ -1391,8 +1327,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-eusd-knox-vault",
@@ -1412,8 +1347,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-eth+-weth-vault",
@@ -1433,8 +1367,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-arb-link-eth-vault",
@@ -1454,8 +1387,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "arb-ltipp",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_balancer-gyro-arb-wsteth-weth-balancer",

--- a/src/config/boost/avax.json
+++ b/src/config/boost/avax.json
@@ -110,8 +110,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_pharaoh-cow-btc.b-wavax-vault",
@@ -131,8 +130,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_pharaoh-cow-weth.e-wavax-vault",
@@ -152,8 +150,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_pharaoh-cow-usdt-usdc-vault",
@@ -173,8 +170,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_gmx-avax-gmx",
@@ -194,8 +190,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_joe-joe",
@@ -215,7 +210,6 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   }
 ]

--- a/src/config/boost/base.json
+++ b/src/config/boost/base.json
@@ -17,8 +17,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aero-cow-wsteth-weth-vault-lido",
@@ -36,8 +35,7 @@
     "partnership": true,
     "status": "active",
     "isMooStaked": true,
-    "partners": ["lido-eth"],
-    "pinned": false
+    "partners": ["lido-eth"]
   },
   {
     "id": "moo_aerodrome-weth-klima",
@@ -57,8 +55,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_alienbase-alb-usdc-wide",
@@ -78,8 +75,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_alienbase-alb-eth-wide",
@@ -99,8 +95,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_alienbase-cbeth-eth-narrow",
@@ -120,8 +115,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_alienbase-usdc-usdbc-narrow",
@@ -141,8 +135,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-msusd-usdc",
@@ -162,8 +155,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": true
+    "partners": []
   },
   {
     "id": "moo_aerodrome-usd+-mai",
@@ -183,8 +175,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-weth-qi",
@@ -204,8 +195,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-virtual-weth",
@@ -225,8 +215,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-virtual-cbbtc",
@@ -246,8 +235,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aero-cow-weth-luna-vault",
@@ -267,8 +255,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-usdc-mai",
@@ -288,8 +275,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-usdc-cbbtc",
@@ -309,8 +295,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-weth-cbbtc",
@@ -330,8 +315,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-weth-silo",
@@ -351,8 +335,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aero-cow-tbtc-cbbtc-vault",
@@ -372,8 +355,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-cow-weth-eurc-vault",
@@ -393,8 +375,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-cow-usdz-weth-vault",
@@ -414,8 +395,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-weth-degen",
@@ -435,8 +415,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-cow-weth-degen-vault",
@@ -456,8 +435,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-cow-degen-usd+-vault",
@@ -477,8 +455,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-jeur-eurc",
@@ -498,8 +475,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-crvusd-usdc",
@@ -519,8 +495,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aero-cow-weth-ovn-vault",
@@ -540,8 +515,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-weth-spx",
@@ -561,8 +535,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aero-cow-doginme-weth-vault",
@@ -582,8 +555,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aero-cow-mog-weth-vault",
@@ -603,8 +575,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aero-cow-weth-moobifi-vault",
@@ -624,8 +595,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-ovn-usd+",
@@ -645,8 +615,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-aero-l2ve",
@@ -666,8 +635,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-aero-wsteth",
@@ -687,8 +655,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-aero-usdbc",
@@ -708,8 +675,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-weth-aero",
@@ -729,8 +695,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-usdc-aero",
@@ -750,8 +715,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-usdz-susdz",
@@ -771,8 +735,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aero-cow-usd+-weth-vault",
@@ -792,8 +755,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-cbbtc-susdz",
@@ -813,8 +775,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aero-cow-weth-zro-vault",
@@ -834,8 +795,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aero-cow-wif-weth-vault",
@@ -855,8 +815,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aero-cow-eurc-cbbtc-vault",
@@ -876,8 +835,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aero-cow-tbtc-usdc-vault",
@@ -897,8 +855,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aero-cow-weth-usdt-vault",
@@ -918,8 +875,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_baseswap-cow-weth-usdc-vault",
@@ -939,8 +895,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aero-cow-weth-usdc-vault",
@@ -960,8 +915,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-weth-bwell",
@@ -981,8 +935,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-weth-usdbc",
@@ -1002,8 +955,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aero-cow-weth-cbbtc-vault",
@@ -1023,8 +975,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aero-cow-usdc-cbbtc-vault",
@@ -1044,8 +995,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aerodrome-tbtc-usdc",
@@ -1065,8 +1015,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_alienbase-cbeth-weth-alienbase2",

--- a/src/config/boost/ethereum.json
+++ b/src/config/boost/ethereum.json
@@ -118,8 +118,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_stargate-v2-eth-weth",
@@ -138,8 +137,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aura-reth-weth",
@@ -158,8 +156,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aura-ezeth-eth",
@@ -178,8 +175,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aura-pxeth-weth",
@@ -198,8 +194,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_convex-eth+",
@@ -218,8 +213,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_convex-cvxcrv",
@@ -239,8 +233,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_convex-cvxeth",
@@ -260,8 +253,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_fx-fxn-eth",
@@ -281,8 +273,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_convex-geareth",
@@ -302,8 +293,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aura-reth-rpl",
@@ -323,8 +313,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_convex-t",
@@ -344,8 +333,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_convex-staked-cvxFXN",
@@ -365,8 +353,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_convex-staked-cvx",
@@ -386,8 +373,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_convex-staked-cvxCRV",
@@ -407,8 +393,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aura-alcx-eth",
@@ -428,7 +413,6 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   }
 ]

--- a/src/config/boost/fraxtal.json
+++ b/src/config/boost/fraxtal.json
@@ -17,7 +17,6 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": true
+    "partners": []
   }
 ]

--- a/src/config/boost/lisk.json
+++ b/src/config/boost/lisk.json
@@ -15,8 +15,7 @@
     "partnership": true,
     "status": "active",
     "isMooStaked": true,
-    "partners": ["lisk"],
-    "pinned": true
+    "partners": ["lisk"]
   },
   {
     "id": "moo_velodrome-cow-lisk-usdt-usdc.e-vault-lisk",
@@ -34,7 +33,6 @@
     "partnership": true,
     "status": "active",
     "isMooStaked": true,
-    "partners": ["lisk"],
-    "pinned": true
+    "partners": ["lisk"]
   }
 ]

--- a/src/config/boost/optimism.json
+++ b/src/config/boost/optimism.json
@@ -17,8 +17,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-wbtc-tbtc",
@@ -38,8 +37,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": true
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-hai-lusd",
@@ -59,8 +57,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_sushi-cow-op-weth-wbtc-vault",
@@ -81,8 +78,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_silo-op-eth-op",
@@ -103,8 +99,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_silo-op-eth-wsteth",
@@ -125,8 +120,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_compound-op-eth",
@@ -147,8 +141,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_compound-op-usdt",
@@ -169,8 +162,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_compound-op-usdc",
@@ -191,8 +183,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-hai-pxeth",
@@ -213,8 +204,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-pxeth-aleth",
@@ -235,8 +225,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velo-cow-op-wsteth-op-vault-beefyclm",
@@ -257,8 +246,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velo-cow-op-weth-tbtc-vault-beefyclm",
@@ -279,8 +267,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velo-cow-op-snx-usdc-vault-beefyclm",
@@ -301,8 +288,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velo-cow-op-wbtc-tbtc-vault-beefyclm",
@@ -323,8 +309,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velo-cow-op-op-usdc-vault-beefyclm",
@@ -345,8 +330,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velo-cow-op-usdc-usdt-vault-beefyclm",
@@ -366,8 +350,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "",
-    "partners": ["beefy-clm"],
-    "pinned": false
+    "partners": ["beefy-clm"]
   },
   {
     "id": "moo_velo-cow-op-wsteth-ezeth-vault-beefyclm",
@@ -387,8 +370,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "",
-    "partners": ["beefy-clm"],
-    "pinned": false
+    "partners": ["beefy-clm"]
   },
   {
     "id": "moo_velo-cow-op-wsteth-weth-vault-beefyclm",
@@ -408,8 +390,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "",
-    "partners": ["beefy-clm"],
-    "pinned": false
+    "partners": ["beefy-clm"]
   },
   {
     "id": "moo_velo-cow-op-weth-wbtc-vault-beefyclm",
@@ -429,8 +410,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "",
-    "partners": ["beefy-clm"],
-    "pinned": false
+    "partners": ["beefy-clm"]
   },
   {
     "id": "moo_velo-cow-op-weth-op-vault-beefyclm",
@@ -451,8 +431,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velo-cow-op-wsteth-usdc-vault-beefyclm",
@@ -472,8 +451,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "",
-    "partners": ["beefy-clm"],
-    "pinned": false
+    "partners": ["beefy-clm"]
   },
   {
     "id": "moo_velo-cow-op-weth-usdc-vault-beefyclm",
@@ -494,8 +472,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": true
+    "partners": []
   },
 
   {
@@ -516,8 +493,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "",
-    "partners": ["beefy-clm"],
-    "pinned": false
+    "partners": ["beefy-clm"]
   },
   {
     "id": "moo_velo-cow-op-moobifi-usdc-vault-beefyclm",
@@ -537,8 +513,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "",
-    "partners": ["beefy-clm"],
-    "pinned": false
+    "partners": ["beefy-clm"]
   },
   {
     "id": "moo_velo-cow-op-moobifi-usdc-vault",
@@ -559,8 +534,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-velo-usdc-beefy",
@@ -1371,8 +1345,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": ["optimism"],
-    "pinned": false
+    "partners": ["optimism"]
   },
   {
     "id": "moo_velodrome-v2-usdce-msusd",
@@ -1393,8 +1366,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": ["optimism"],
-    "pinned": false
+    "partners": ["optimism"]
   },
   {
     "id": "moo_velodrome-v2-usdc-alusd-2",
@@ -1415,8 +1387,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": ["optimism"],
-    "pinned": false
+    "partners": ["optimism"]
   },
   {
     "id": "moo_curve-op-usdc-usdm",
@@ -1437,8 +1408,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": ["optimism"],
-    "pinned": false
+    "partners": ["optimism"]
   },
   {
     "id": "moo_velodrome-v2-hai-susd",
@@ -1459,8 +1429,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": ["optimism"],
-    "pinned": false
+    "partners": ["optimism"]
   },
   {
     "id": "moo_velodrome-v2-frax-dola",
@@ -1481,8 +1450,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": ["optimism"],
-    "pinned": false
+    "partners": ["optimism"]
   },
   {
     "id": "moo_stargate-v2-op-weth",
@@ -1502,8 +1470,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-mseth-weth",
@@ -1524,8 +1491,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-aleth-weth",
@@ -1545,8 +1511,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-pxeth-weth",
@@ -1566,8 +1531,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-velo-usdc",
@@ -1588,8 +1552,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_curve-op-tricrv",
@@ -1610,8 +1573,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-weth-tlx",
@@ -1632,8 +1594,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-op-velo",
@@ -1654,8 +1615,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-weth-velo",
@@ -1676,8 +1636,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-usdc-stg",
@@ -1698,8 +1657,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-wsteth-pendle",
@@ -1720,8 +1678,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-thales-weth",
@@ -1742,8 +1699,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-weth-kwenta",
@@ -1764,8 +1720,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-usdc-velo",
@@ -1786,8 +1741,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velo-cow-op-moobifi-usdc-vault-2",
@@ -1807,8 +1761,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": true
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-weth-moobifi",
@@ -1828,8 +1781,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_sushi-cow-op-weth-op-vault",
@@ -1850,8 +1802,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_sushi-cow-op-usdc-weth-vault",
@@ -1872,8 +1823,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_curve-op-tricrypto-crvusd",
@@ -1894,8 +1844,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_stargate-v2-op-usdt",
@@ -1916,8 +1865,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_stargate-v2-op-usdc",
@@ -1938,8 +1886,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_aura-op-weth-wrseth",
@@ -1960,8 +1907,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-weth-owell",
@@ -1982,8 +1928,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-wsteth-wusdm",
@@ -2004,8 +1949,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_silo-op-usdc-wsteth",
@@ -2026,8 +1970,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-wsteth-weeth",
@@ -2048,8 +1991,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_velodrome-v2-msop-op",
@@ -2070,7 +2012,6 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "zap-v3",
-    "partners": [],
-    "pinned": false
+    "partners": []
   }
 ]

--- a/src/config/boost/polygon.json
+++ b/src/config/boost/polygon.json
@@ -17,8 +17,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_retro-gamma-usdc-cash-retro",

--- a/src/config/boost/rootstock.json
+++ b/src/config/boost/rootstock.json
@@ -17,8 +17,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "rootstock-grant",
-    "partners": [],
-    "pinned": true
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-rootstock-wrbtc-rusdt-vault",
@@ -38,8 +37,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "rootstock-grant",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_uniswap-cow-rootstock-doc-rusdt-vault",
@@ -59,8 +57,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "rootstock-grant",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_sushi-cow-rootstock-eths-wrbtc-vault",
@@ -80,8 +77,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "rootstock-grant",
-    "partners": [],
-    "pinned": true
+    "partners": []
   },
   {
     "id": "moo_sushi-cow-rootstock-wrbtc-rusdt-vault",
@@ -101,8 +97,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "rootstock-grant",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_sushi-cow-rootstock-doc-rusdt-vault",
@@ -122,7 +117,6 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "rootstock-grant",
-    "partners": [],
-    "pinned": false
+    "partners": []
   }
 ]

--- a/src/config/boost/scroll.json
+++ b/src/config/boost/scroll.json
@@ -17,8 +17,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": true
+    "partners": []
   },
   {
     "id": "moo_nuri-cow-scroll-weth-wsteth-vault",
@@ -38,8 +37,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": true
+    "partners": []
   },
   {
     "id": "moo_nuri-cow-scroll-weth-usdt-vault",
@@ -59,8 +57,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": true
+    "partners": []
   },
   {
     "id": "moo_nuri-cow-scroll-usdc-weth-vault",
@@ -80,8 +77,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": true
+    "partners": []
   },
   {
     "id": "moo_nuri-cow-scroll-usdc-scr-vault",
@@ -101,8 +97,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_nuri-cow-scroll-weth-scr-vault",
@@ -122,8 +117,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
   {
     "id": "moo_nuri-usdc-loreusd",
@@ -143,28 +137,26 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": false
+    "partners": []
   },
-    {
-      "id": "moo_nuri-weth-nuri",
-      "poolId": "nuri-weth-nuri",
-      "name": "Beefy",
-      "tagText": "DAO Boost",
-      "assets": ["NURI", "ETH"],
-      "tokenAddress": "0x01Fbf9B624a6133Ab04Fc4000ae513AC97e4d114",
-      "earnedToken": "USDC",
-      "earnedTokenDecimals": 6,
-      "earnedTokenAddress": "0x06eFdBFf2a14a7c8E15944D1F4A48F9F95F663A4",
-      "earnContractAddress": "0xeC982aF0f2250Acf5bA0404D6672384349A57241",
-      "version": 2,
-      "earnedOracle": "tokens",
-      "earnedOracleId": "USDC",
-      "partnership": true,
-      "status": "active",
-      "isMooStaked": true,
-      "campaign": "dao-rewards",
-      "partners": [],
-      "pinned": false
-    }
+  {
+    "id": "moo_nuri-weth-nuri",
+    "poolId": "nuri-weth-nuri",
+    "name": "Beefy",
+    "tagText": "DAO Boost",
+    "assets": ["NURI", "ETH"],
+    "tokenAddress": "0x01Fbf9B624a6133Ab04Fc4000ae513AC97e4d114",
+    "earnedToken": "USDC",
+    "earnedTokenDecimals": 6,
+    "earnedTokenAddress": "0x06eFdBFf2a14a7c8E15944D1F4A48F9F95F663A4",
+    "earnContractAddress": "0xeC982aF0f2250Acf5bA0404D6672384349A57241",
+    "version": 2,
+    "earnedOracle": "tokens",
+    "earnedOracleId": "USDC",
+    "partnership": true,
+    "status": "active",
+    "isMooStaked": true,
+    "campaign": "dao-rewards",
+    "partners": []
+  }
 ]

--- a/src/config/boost/zksync.json
+++ b/src/config/boost/zksync.json
@@ -17,8 +17,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": true
+    "partners": []
   },
   {
     "id": "moo_venus-zksync-usdt",
@@ -38,8 +37,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": true
+    "partners": []
   },
   {
     "id": "moo_venus-zksync-wbtc",
@@ -59,8 +57,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": true
+    "partners": []
   },
   {
     "id": "moo_venus-zksync-weth",
@@ -80,8 +77,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": true
+    "partners": []
   },
   {
     "id": "moo_venus-zksync-zk",
@@ -101,8 +97,7 @@
     "status": "active",
     "isMooStaked": true,
     "campaign": "dao-rewards",
-    "partners": [],
-    "pinned": true
+    "partners": []
   },
   {
     "id": "moo_vesync-usdc-wtbt-tprotocol",

--- a/src/config/pinned.json
+++ b/src/config/pinned.json
@@ -1,0 +1,10 @@
+[
+  {
+    "conditions": [
+      {
+        "type": "boosted",
+        "contractPinned": true
+      }
+    ]
+  }
+]

--- a/src/config/pinned.json
+++ b/src/config/pinned.json
@@ -1,9 +1,29 @@
 [
   {
+    "id": [
+      "uniswap-cow-rootstock-eths-wrbtc-vault",
+      "sushi-cow-rootstock-eths-wrbtc-vault",
+      "aerodrome-msusd-usdc",
+      "curve-lend-fraxtal-sfrax-crvusd",
+      "velodrome-cow-lisk-usdt-weth-vault",
+      "velodrome-cow-lisk-usdt-usdc.e-vault",
+      "velodrome-v2-wbtc-tbtc",
+      "velo-cow-op-weth-usdc-vault",
+      "velo-cow-op-moobifi-usdc-vault",
+      "nuri-cow-scroll-wbtc-weth-vault",
+      "nuri-cow-scroll-weth-wsteth-vault",
+      "nuri-cow-scroll-weth-usdt-vault",
+      "nuri-cow-scroll-usdc-weth-vault",
+      "venus-zksync-usdc.e",
+      "venus-zksync-usdt",
+      "venus-zksync-wbtc",
+      "venus-zksync-weth",
+      "venus-zksync-zk"
+    ],
     "conditions": [
       {
         "type": "boosted",
-        "contractPinned": true
+        "contract": true
       }
     ]
   }

--- a/src/features/data/actions/filtered-vaults.ts
+++ b/src/features/data/actions/filtered-vaults.ts
@@ -13,7 +13,6 @@ import {
   selectFilterOptions,
   selectFilterPlatformIdsForVault,
   selectVaultIsBoostedForFilter,
-  selectVaultIsBoostedForSorting,
   selectVaultMatchesText,
 } from '../selectors/filtered-vaults';
 import {
@@ -22,6 +21,7 @@ import {
   selectIsVaultCorrelated,
   selectIsVaultStable,
   selectVaultById,
+  selectVaultIsPinned,
 } from '../selectors/vaults';
 import { selectActiveChainIds, selectAllChainIds } from '../selectors/chains';
 import { selectVaultSupportsZap } from '../selectors/zap';
@@ -255,9 +255,9 @@ function applyDefaultSort(
   vaults: VaultEntity[],
   filters: FilteredVaultsState
 ): VaultEntity['id'][] {
-  const boostedVaultsToPin = new Set<VaultEntity['id']>(
+  const vaultsToPin = new Set<VaultEntity['id']>(
     vaults
-      .filter(vault => vault.status === 'active' && selectVaultIsBoostedForSorting(state, vault.id))
+      .filter(vault => vault.status === 'active' && selectVaultIsPinned(state, vault.id))
       .map(v => v.id)
   );
 
@@ -268,7 +268,7 @@ function applyDefaultSort(
         ? -3
         : vault.status === 'paused'
         ? -2
-        : boostedVaultsToPin.has(vault.id)
+        : vaultsToPin.has(vault.id)
         ? -1
         : 1
     ).map(v => v.id);
@@ -276,7 +276,7 @@ function applyDefaultSort(
 
   // Surface boosted
   return sortBy(vaults, vault =>
-    boostedVaultsToPin.has(vault.id)
+    vaultsToPin.has(vault.id)
       ? selectIsVaultPrestakedBoost(state, vault.id)
         ? -Number.MAX_SAFE_INTEGER
         : -selectVaultsActiveBoostPeriodFinish(state, vault.id)

--- a/src/features/data/actions/scenarios.ts
+++ b/src/features/data/actions/scenarios.ts
@@ -7,7 +7,7 @@ import { fetchApyAction } from './apy';
 import { fetchAllBoosts } from './boosts';
 import { fetchChainConfigs } from './chains';
 import { fetchAllPricesAction } from './prices';
-import { fetchAllVaults, fetchVaultsLastHarvests } from './vaults';
+import { fetchAllVaults, fetchVaultsLastHarvests, fetchVaultsPinnedConfig } from './vaults';
 import { fetchAllBalanceAction } from './balance';
 import { fetchAllContractDataByChainAction } from './contract-data';
 import { featureFlag_noDataPolling } from '../utils/feature-flags';
@@ -64,6 +64,8 @@ export async function initAppData(store: BeefyStore) {
   setTimeout(async () => {
     // we can start fetching apy, it will arrive when it wants, nothing depends on it
     store.dispatch(fetchApyAction());
+
+    store.dispatch(fetchVaultsPinnedConfig());
 
     store.dispatch(fetchPartnersConfig());
 

--- a/src/features/data/actions/vaults.ts
+++ b/src/features/data/actions/vaults.ts
@@ -19,7 +19,7 @@ import { getVaultNames } from '../utils/vault-utils';
 import { safetyScoreNum } from '../../../helpers/safetyScore';
 import { isDefined } from '../utils/array-utils';
 import { selectAllVisibleVaultIds, selectVaultsPinnedConfigs } from '../selectors/vaults';
-import { selectBoostById, selectVaultCurrentBoostId } from '../selectors/boosts';
+import { selectVaultCurrentBoostId } from '../selectors/boosts';
 import { selectVaultHasActiveOffchainCampaigns } from '../selectors/rewards';
 import { getUnixNow } from '../../../helpers/date';
 import { selectVaultTotalApy } from '../selectors/apy';
@@ -360,18 +360,10 @@ function selectVaultMatchesCondition(
 ) {
   switch (condition.type) {
     case 'boosted': {
-      if (condition.contract || condition.contractPinned) {
+      if (condition.contract) {
         const boostId = selectVaultCurrentBoostId(state, vaultId);
         if (boostId) {
-          // do not care if the boost was pinned in config or not
-          if (condition.contract) {
-            return true;
-          }
-          // must be pinned in the boost config too
-          const boost = selectBoostById(state, boostId);
-          if (boost.pinned) {
-            return true;
-          }
+          return true;
         }
       }
       if (condition.offchain) {

--- a/src/features/data/actions/vaults.ts
+++ b/src/features/data/actions/vaults.ts
@@ -2,8 +2,8 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import type { BeefyState } from '../../../redux-types';
 import { getBeefyApi, getConfigApi } from '../apis/instances';
 import type { ChainEntity, ChainId } from '../entities/chain';
-import type { VaultConfig } from '../apis/config-types';
-import { first, keyBy, mapValues } from 'lodash-es';
+import type { PinnedConfig, PinnedConfigCondition, VaultConfig } from '../apis/config-types';
+import { first, isEqual, keyBy, mapValues } from 'lodash-es';
 import {
   type VaultBase,
   type VaultCowcentrated,
@@ -18,6 +18,11 @@ import {
 import { getVaultNames } from '../utils/vault-utils';
 import { safetyScoreNum } from '../../../helpers/safetyScore';
 import { isDefined } from '../utils/array-utils';
+import { selectAllVisibleVaultIds, selectVaultsPinnedConfigs } from '../selectors/vaults';
+import { selectBoostById, selectVaultCurrentBoostId } from '../selectors/boosts';
+import { selectVaultHasActiveOffchainCampaigns } from '../selectors/rewards';
+import { getUnixNow } from '../../../helpers/date';
+import { selectVaultTotalApy } from '../selectors/apy';
 
 export interface FulfilledAllVaultsPayload {
   byChainId: {
@@ -330,3 +335,108 @@ function getVaultBase(config: VaultConfig, chainId: ChainEntity['id']): VaultBas
     breakdownId: config.oracle === 'tokens' ? config.id : config.oracleId, // use vault id when deposit token is not a LP
   };
 }
+
+type FulfilledVaultsPinnedConfigPayload = {
+  configs: PinnedConfig[];
+};
+
+export const fetchVaultsPinnedConfig = createAsyncThunk<FulfilledVaultsPinnedConfigPayload>(
+  'vaults/pinned-config',
+  async () => {
+    const api = await getConfigApi();
+    const configs = await api.fetchPinnedConfig();
+    return { configs };
+  }
+);
+
+type FulfilledVaultsPinnedPayload = {
+  byId: { [vaultId: VaultConfig['id']]: boolean };
+};
+
+function selectVaultMatchesCondition(
+  state: BeefyState,
+  vaultId: string,
+  condition: PinnedConfigCondition
+) {
+  switch (condition.type) {
+    case 'boosted': {
+      if (condition.contract || condition.contractPinned) {
+        const boostId = selectVaultCurrentBoostId(state, vaultId);
+        if (boostId) {
+          // do not care if the boost was pinned in config or not
+          if (condition.contract) {
+            return true;
+          }
+          // must be pinned in the boost config too
+          const boost = selectBoostById(state, boostId);
+          if (boost.pinned) {
+            return true;
+          }
+        }
+      }
+      if (condition.offchain) {
+        const hasOffchainCampaign = selectVaultHasActiveOffchainCampaigns(state, vaultId);
+        if (hasOffchainCampaign) {
+          return true;
+        }
+      }
+      if (condition.other) {
+        const apy = selectVaultTotalApy(state, vaultId);
+        if (!!apy && (apy.boostedTotalDaily || 0) > 0) {
+          return true;
+        }
+      }
+      return false;
+    }
+    case 'until': {
+      return getUnixNow() <= condition.timestamp;
+    }
+    default: {
+      // @ts-expect-error when all cases are covered
+      throw new Error(`Unknown pinned condition type ${condition.type}`);
+    }
+  }
+}
+
+function selectVaultMatchesConditions(
+  state: BeefyState,
+  vaultId: string,
+  conditions: PinnedConfigCondition[]
+) {
+  return conditions.every(condition => selectVaultMatchesCondition(state, vaultId, condition));
+}
+
+export const vaultsRecalculatePinned = createAsyncThunk<
+  FulfilledVaultsPinnedPayload,
+  void,
+  { state: BeefyState }
+>('vaults/recalculate-pinned', async (_, { getState }) => {
+  const state = getState();
+  const configs = selectVaultsPinnedConfigs(state);
+  const byId: Record<string, boolean> = {};
+  const allVaultIds = selectAllVisibleVaultIds(state);
+
+  for (const config of configs) {
+    const ids = config.id ? [config.id] : allVaultIds;
+
+    for (const id of ids) {
+      // already pinned by another condition
+      if (byId[id]) {
+        continue;
+      }
+      // condition-less pin
+      if (!config.conditions) {
+        byId[id] = true;
+        continue;
+      }
+      // pin if all conditions are met
+      if (selectVaultMatchesConditions(state, id, config.conditions)) {
+        byId[id] = true;
+      }
+    }
+  }
+
+  // return same object if nothing changed
+  const existingById = state.entities.vaults.pinned.byId;
+  return { byId: isEqual(existingById, byId) ? existingById : byId };
+});

--- a/src/features/data/apis/config-types.ts
+++ b/src/features/data/apis/config-types.ts
@@ -121,7 +121,6 @@ export interface BoostConfig {
   partners?: string[] | undefined;
   campaign?: string | undefined;
   fixedStatus?: boolean | null;
-  pinned?: boolean | undefined;
   /** tmp: exclude from being loaded */
   hidden?: boolean;
 }
@@ -544,8 +543,6 @@ export type PinnedConfigConditionUntil = {
 
 export type PinnedConfigConditionBoosted = {
   type: 'boosted';
-  /** active pinned boost contract [default: false] */
-  contractPinned?: boolean;
   /** active boost contract [default: false] */
   contract?: boolean;
   /** active offchain campaign [default: false] */

--- a/src/features/data/apis/config-types.ts
+++ b/src/features/data/apis/config-types.ts
@@ -536,3 +536,28 @@ export type BeefyBridgeConfig = Readonly<{
    */
   bridges: ReadonlyArray<BeefyAnyBridgeConfig>;
 }>;
+
+export type PinnedConfigConditionUntil = {
+  type: 'until';
+  timestamp: number;
+};
+
+export type PinnedConfigConditionBoosted = {
+  type: 'boosted';
+  /** active pinned boost contract [default: false] */
+  contractPinned?: boolean;
+  /** active boost contract [default: false] */
+  contract?: boolean;
+  /** active offchain campaign [default: false] */
+  offchain?: boolean;
+  /** boostedTotalDaily apr > 0 [default: false] */
+  other?: boolean;
+};
+
+export type PinnedConfigCondition = PinnedConfigConditionUntil | PinnedConfigConditionBoosted;
+
+export type PinnedConfig = {
+  /** vault id, undefined = all vaults */
+  id?: string;
+  conditions: Array<PinnedConfigCondition>;
+};

--- a/src/features/data/apis/config-types.ts
+++ b/src/features/data/apis/config-types.ts
@@ -557,7 +557,9 @@ export type PinnedConfigConditionBoosted = {
 export type PinnedConfigCondition = PinnedConfigConditionUntil | PinnedConfigConditionBoosted;
 
 export type PinnedConfig = {
-  /** vault id, undefined = all vaults */
-  id?: string;
+  /** vault id, or array of vault ids, undefined = all vaults */
+  id?: string | string[];
+  /** all conditions must match, or only one of them [default: all] */
+  mode?: 'all' | 'any';
   conditions: Array<PinnedConfigCondition>;
 };

--- a/src/features/data/apis/config.ts
+++ b/src/features/data/apis/config.ts
@@ -10,6 +10,7 @@ import type {
   ChainConfig,
   MinterConfig,
   PartnersConfig,
+  PinnedConfig,
   PlatformConfig,
   PlatformType,
   SwapAggregatorConfig,
@@ -140,5 +141,9 @@ export class ConfigAPI {
 
   public async fetchBridges(): Promise<BridgeConfig[]> {
     return (await import('../../../config/bridges.json')).default;
+  }
+
+  public async fetchPinnedConfig(): Promise<PinnedConfig[]> {
+    return (await import('../../../config/pinned.json')).default as PinnedConfig[];
   }
 }

--- a/src/features/data/entities/boost.ts
+++ b/src/features/data/entities/boost.ts
@@ -38,8 +38,6 @@ export interface BoostEntity {
   partnerIds: BoostPartnerEntity['id'][];
 
   campaignId: BoostCampaignEntity['id'] | undefined;
-
-  pinned: boolean;
 }
 
 export type BoostPartnerEntity = BoostPartnerConfig & {

--- a/src/features/data/middlewares/filtered-vaults.ts
+++ b/src/features/data/middlewares/filtered-vaults.ts
@@ -6,7 +6,7 @@ import {
   recalculateDepositedVaultsAction,
 } from '../actions/balance';
 import { reloadBalanceAndAllowanceAndGovRewardsAndBoostData } from '../actions/tokens';
-import { fetchAllVaults } from '../actions/vaults';
+import { fetchAllVaults, vaultsRecalculatePinned } from '../actions/vaults';
 import { fetchAllPricesAction } from '../actions/prices';
 import { fetchApyAction } from '../actions/apy';
 import { fetchAllBoosts } from '../actions/boosts';
@@ -119,6 +119,7 @@ function listenForChanges() {
       await delay(500);
 
       // Recalculate
+      await dispatch(vaultsRecalculatePinned());
       await dispatch(recalculateFilteredVaultsAction({ dataChanged: true }));
     },
   });

--- a/src/features/data/reducers/boosts.ts
+++ b/src/features/data/reducers/boosts.ts
@@ -239,7 +239,6 @@ function addBoostToState(
     campaignId: apiBoost.campaign ? apiBoost.campaign : undefined,
     vaultId: apiBoost.poolId,
     version: apiBoost.version || 1,
-    pinned: apiBoost.pinned === undefined ? true : apiBoost.pinned, // default to true
   };
   sliceState.byId[boost.id] = boost;
   sliceState.allIds.push(boost.id);

--- a/src/features/data/reducers/vaults.ts
+++ b/src/features/data/reducers/vaults.ts
@@ -4,13 +4,19 @@ import type { Draft } from 'immer';
 import { sortBy } from 'lodash-es';
 import { fetchAllContractDataByChainAction } from '../actions/contract-data';
 import { reloadBalanceAndAllowanceAndGovRewardsAndBoostData } from '../actions/tokens';
-import { fetchAllVaults, fetchVaultsLastHarvests } from '../actions/vaults';
+import {
+  fetchAllVaults,
+  fetchVaultsLastHarvests,
+  fetchVaultsPinnedConfig,
+  vaultsRecalculatePinned,
+} from '../actions/vaults';
 import type { FetchAllContractDataResult } from '../apis/contract-data/contract-data-types';
 import type { ChainEntity } from '../entities/chain';
 import { isStandardVault, type VaultEntity } from '../entities/vault';
 import type { NormalizedEntity } from '../utils/normalized-entity';
 import { fromKeysBy, pushOrSet } from '../../../helpers/object';
 import { BIG_ZERO } from '../../../helpers/big-number';
+import type { PinnedConfig } from '../apis/config-types';
 
 /**
  * State containing Vault infos
@@ -94,6 +100,13 @@ export type VaultsState = NormalizedEntity<VaultEntity> & {
   lastHarvestById: {
     [vaultId: VaultEntity['id']]: number;
   };
+
+  pinned: {
+    configs: PinnedConfig[];
+    byId: {
+      [vaultId: VaultEntity['id']]: boolean;
+    };
+  };
 };
 
 export const initialVaultsState: VaultsState = {
@@ -125,6 +138,10 @@ export const initialVaultsState: VaultsState = {
   byChainId: {},
   contractData: { byVaultId: {} },
   lastHarvestById: {},
+  pinned: {
+    configs: [],
+    byId: {},
+  },
 };
 
 export const vaultsSlice = createSlice({
@@ -160,6 +177,14 @@ export const vaultsSlice = createSlice({
         addContractDataToState(sliceState, action.payload.contractData);
       }
     );
+
+    builder
+      .addCase(fetchVaultsPinnedConfig.fulfilled, (sliceState, action) => {
+        sliceState.pinned.configs = action.payload.configs;
+      })
+      .addCase(vaultsRecalculatePinned.fulfilled, (sliceState, action) => {
+        sliceState.pinned.byId = action.payload.byId;
+      });
   },
 });
 

--- a/src/features/data/selectors/filtered-vaults.ts
+++ b/src/features/data/selectors/filtered-vaults.ts
@@ -2,11 +2,7 @@ import { createSelector } from '@reduxjs/toolkit';
 import type { BeefyState } from '../../../redux-types';
 import { type VaultEntity } from '../entities/vault';
 import { selectUserDepositedVaultIds } from './balance';
-import {
-  selectBoostById,
-  selectIsVaultPreStakedOrBoosted,
-  selectVaultCurrentBoostId,
-} from './boosts';
+import { selectIsVaultPreStakedOrBoosted } from './boosts';
 import { selectAllVisibleVaultIds, selectVaultById } from './vaults';
 import { selectTokenByAddress, selectVaultTokenSymbols } from './tokens';
 import { createCachedSelector } from 're-reselect';
@@ -201,18 +197,4 @@ export const selectVaultIsBoostedForFilter = (state: BeefyState, vaultId: VaultE
 
   const apy = selectVaultTotalApy(state, vaultId);
   return !!apy && (apy.boostedTotalDaily || 0) > 0;
-};
-
-export const selectVaultIsBoostedForSorting = (state: BeefyState, vaultId: VaultEntity['id']) => {
-  const boostId = selectVaultCurrentBoostId(state, vaultId);
-  if (!boostId) {
-    return false;
-  }
-
-  const boost = selectBoostById(state, boostId);
-  if (!boost) {
-    return false;
-  }
-
-  return boost.pinned;
 };

--- a/src/features/data/selectors/rewards.ts
+++ b/src/features/data/selectors/rewards.ts
@@ -82,6 +82,11 @@ export const selectVaultHasActiveStellaSwapCampaigns = createSelector(
   campaigns => !!campaigns && campaigns.length > 0
 );
 
+export const selectVaultHasActiveOffchainCampaigns = createSelector(
+  (state: BeefyState, vaultId: VaultEntity['id']) => state.biz.rewards.offchain.byVaultId[vaultId],
+  campaigns => !!campaigns && campaigns.length > 0 && campaigns.some(c => c.apr > 0)
+);
+
 export const selectVaultActiveGovRewards = createSelector(
   (state: BeefyState, vaultId: VaultEntity['id']) => state.biz.rewards.gov.byVaultId[vaultId],
   selectVaultRawTvl,

--- a/src/features/data/selectors/vaults.ts
+++ b/src/features/data/selectors/vaults.ts
@@ -468,3 +468,9 @@ export const selectAllCowcentratedVaults = createSelector(
   (clmIds, vaultsById): VaultCowcentrated[] =>
     clmIds.map(id => vaultsById[id]).filter(isCowcentratedVault)
 );
+
+export const selectVaultsPinnedConfigs = (state: BeefyState) =>
+  state.entities.vaults.pinned.configs;
+
+export const selectVaultIsPinned = (state: BeefyState, vaultId: VaultEntity['id']) =>
+  state.entities.vaults.pinned.byId[vaultId] || false;


### PR DESCRIPTION
Options
```typescript
export type PinnedConfigConditionUntil = {
  type: 'until';
  timestamp: number;
};

export type PinnedConfigConditionBoosted = {
  type: 'boosted';
  /** active boost contract [default: false] */
  contract?: boolean;
  /** active offchain campaign [default: false] */
  offchain?: boolean;
  /** boostedTotalDaily apr > 0 [default: false] */
  other?: boolean;
};

export type PinnedConfigCondition = PinnedConfigConditionUntil | PinnedConfigConditionBoosted;

export type PinnedConfig = {
  /** vault id, or array of vault ids, undefined = all vaults */
  id?: string | string[];
  /** must match all conditions */
  conditions: Array<PinnedConfigCondition>;
};
```

Example:
```json
[
  {
    "conditions": [
      {
        "type": "boosted",
        "contractPinned": true
      }
    ]
  },
  {
    "id": "velodrome-cow-optimism-aleth-alusd-rp",
    "conditions": [
      {
        "type": "until",
        "timestamp": 1740229569
      }
    ]
  },
  {
    "id": "shadow-cow-sonic-ws-usdc.e-vault"
  },
  {
    "id": "stellaswap-cow-moonbeam-stdot-xcdot-rp",
    "conditions": [
      {
        "type": "boosted",
        "offchain": true
      }
    ]
  }
]
```
1. Any vault that is boosted and the boost has pinned set to true
2. velodrome-cow-optimism-aleth-alusd-rp until Sat Feb 22 2025 13:06:09 UTC
3. shadow-cow-sonic-ws-usdc.e-vault always
4. stellaswap-cow-moonbeam-stdot-xcdot-rp if there is an active off chain campaign (merkl/stellaswap)