### PR TITLE
Fix typo 'ABasUSDC' --> 'aBasUSDC'

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -591,7 +591,7 @@ export const config = {
       'smUSDC',
       'OUSDT',
       'BOLDV2',
-      'ABasUSDC',
+      'aBasUSDC',
     ],
   },
   gnosis: {


### PR DESCRIPTION
Typo