### PR TITLE
Add 5 x Aerodrome CLMs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,22 +90,6 @@
         "node": "^20.18.2 || ^22.14.0"
       }
     },
-    "../../API/beefy-api/packages/address-book": {
-      "name": "@beefyfinance/blockchain-addressbook",
-      "version": "0.54.159",
-      "extraneous": true,
-      "license": "MIT",
-      "devDependencies": {
-        "@ethereumjs/util": "^9.0.3",
-        "@types/node": "^24.10.3",
-        "bun": "^1.3.4",
-        "cross-env": "^10.1.0",
-        "eslint": "^9.5.0",
-        "prettier": "^3.3.2",
-        "typescript": "^5.5.2",
-        "typescript-eslint": "^8.49.0"
-      }
-    },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",


### PR DESCRIPTION
Build will fail as awaiting suboracles for VEIL and bHYPE requested in [API PR](https://github.com/beefyfinance/beefy-api/pull/1714)