### PR TITLE
[Fix] Swap Recovery Flow

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -576,7 +576,7 @@ export const config = {
     name: 'Canto',
     chainId: 7700,
     eol: 1734101117,
-    rpc: ['https://canto-rpc.ansybl.io'],
+    rpc: ['https://canto.gravitychain.io'],
     explorerUrl: 'https://tuber.build',
     multicall3Address: '0xcA11bde05977b3631167028862bE2a173976CA11',
     appMulticallContractAddress: '0x7c7B7FbccA5699175003ecbe1B41E79F40385469',

--- a/src/features/data/actions/wallet/cross-chain.ts
+++ b/src/features/data/actions/wallet/cross-chain.ts
@@ -510,7 +510,12 @@ export const crossChainFetchRecoveryQuote = createAppAsyncThunk<
 
   const api = await getTransactApi();
   const actualBridgedAmount = new BigNumber(op.recovery.bridgedAmount);
-  const quote = await api.fetchRecoveryQuote(op.recovery, actualBridgedAmount, getState);
+  const quote = await api.fetchRecoveryQuote(
+    op.recovery,
+    actualBridgedAmount,
+    getState,
+    op.vaultId
+  );
 
   return { quote };
 });
@@ -598,7 +603,8 @@ export function crossChainRecoverySteps(opId: string, t: TFunction<Namespace>): 
         opId,
         actualBridgedAmount,
         getState,
-        t
+        t,
+        op.vaultId
       );
       steps.push(recoveryStep);
 

--- a/src/features/data/apis/transact/strategies/IStrategy.ts
+++ b/src/features/data/apis/transact/strategies/IStrategy.ts
@@ -146,6 +146,12 @@ export type ZapTransactHelpers = BaseTransactHelpers & {
 
 export type TransactHelpers = ZaplessTransactHelpers | ZapTransactHelpers;
 
+export type ChainTransactHelpers = {
+  zap: ZapEntity;
+  swapAggregator: ISwapAggregator;
+  getState: () => BeefyState;
+};
+
 export function isZapTransactHelpers(helpers: TransactHelpers): helpers is ZapTransactHelpers {
   return helpers.zap !== undefined;
 }

--- a/src/features/data/apis/transact/strategies/cross-chain/CrossChainStrategy.ts
+++ b/src/features/data/apis/transact/strategies/cross-chain/CrossChainStrategy.ts
@@ -67,6 +67,7 @@ import {
 import { fetchZapAggregatorSwap } from '../../zap/swap.ts';
 import type { UserlessZapRequest, ZapStep, OrderOutput } from '../../zap/types.ts';
 import {
+  type ChainTransactHelpers,
   type IStrategy,
   type IZapStrategy,
   type IZapStrategyStatic,
@@ -208,9 +209,7 @@ class CrossChainStrategyImpl implements IZapStrategy<StrategyId> {
       timeEstimate: bridgeQuote.timeEstimate,
     } satisfies ZapQuoteStepBridge);
     // C. Destination strategy: find one that accepts destUSDC and quote it
-    const destHelpers = await (
-      await getTransactApi()
-    ).getHelpersForChain(destChainId, option.vaultId, getState);
+    const destHelpers = await (await getTransactApi()).getHelpersForVault(option.vaultId, getState);
     const destStrategies = await (await getTransactApi()).getZapStrategiesForVault(destHelpers);
     const destMatch = await this.findDestStrategyForDeposit(destStrategies, destBridgeToken);
     if (!destMatch) {
@@ -338,7 +337,7 @@ class CrossChainStrategyImpl implements IZapStrategy<StrategyId> {
 
     const destHelpers = await (
       await getTransactApi()
-    ).getHelpersForChain(destChainId, quote.option.vaultId, getState);
+    ).getHelpersForVault(quote.option.vaultId, getState);
     const destStrategies = await (await getTransactApi()).getZapStrategiesForVault(destHelpers);
     const destStrategy = destStrategies.find(s => s.id === stepDestQuote.option.strategyId);
     if (!destStrategy || !isComposableStrategy(destStrategy)) {
@@ -985,7 +984,6 @@ class CrossChainStrategyImpl implements IZapStrategy<StrategyId> {
       recovery = {
         direction: 'withdraw',
         destChainId,
-        vaultId,
         bridgeTokenAddress: bridgedAmount.token.address,
         bridgedAmount: bridgedAmount.amount.toString(10),
         desiredOutputAddress:
@@ -1022,9 +1020,7 @@ class CrossChainStrategyImpl implements IZapStrategy<StrategyId> {
     const state = getState();
     const { destChainId, vaultId, bridgedAmount, bridgeToken } = params;
 
-    const destHelpers = await (
-      await getTransactApi()
-    ).getHelpersForChain(destChainId, vaultId, getState);
+    const destHelpers = await (await getTransactApi()).getHelpersForVault(vaultId, getState);
     const destStrategies = await (await getTransactApi()).getZapStrategiesForVault(destHelpers);
 
     const destMatch = await this.findDestStrategyForDeposit(destStrategies, bridgeToken);
@@ -1087,9 +1083,7 @@ class CrossChainStrategyImpl implements IZapStrategy<StrategyId> {
     }
 
     // 1. Resolve dest helpers and strategies
-    const destHelpers = await (
-      await getTransactApi()
-    ).getHelpersForChain(destChainId, vaultId, getState);
+    const destHelpers = await (await getTransactApi()).getHelpersForVault(vaultId, getState);
     const destStrategies = await (await getTransactApi()).getZapStrategiesForVault(destHelpers);
 
     // 2. Find composable dest strategy that accepts USDC
@@ -1172,21 +1166,20 @@ class CrossChainStrategyImpl implements IZapStrategy<StrategyId> {
    */
   async fetchDestinationWithdrawQuote(params: {
     destChainId: ChainEntity['id'];
-    vaultId: VaultEntity['id'];
     bridgedAmount: BigNumber;
     bridgeToken: TokenErc20;
     desiredOutput: TokenEntity;
+    destChainHelpers: ChainTransactHelpers;
   }): Promise<RecoveryQuote> {
-    const { swapAggregator, getState } = this.helpers;
+    const { swapAggregator, getState } = params.destChainHelpers;
     const state = getState();
-    const { vaultId, bridgedAmount, bridgeToken, desiredOutput } = params;
+    const { destChainId, bridgedAmount, bridgeToken, desiredOutput } = params;
 
     const destSwapQuotes = await swapAggregator.fetchQuotes(
       {
         fromToken: bridgeToken,
         fromAmount: bridgedAmount,
         toToken: desiredOutput,
-        vaultId,
       },
       state,
       this.options.swap
@@ -1212,7 +1205,7 @@ class CrossChainStrategyImpl implements IZapStrategy<StrategyId> {
     const outputs: TokenAmount[] = [{ token: desiredOutput, amount: bestSwap.toAmount }];
 
     return {
-      id: createQuoteId(`recovery-withdraw-${vaultId}`),
+      id: createQuoteId(`recovery-withdraw-${destChainId}`),
       inputs,
       outputs,
       returned: [],
@@ -1231,14 +1224,15 @@ class CrossChainStrategyImpl implements IZapStrategy<StrategyId> {
     params: {
       opId: string;
       destChainId: ChainEntity['id'];
-      vaultId: VaultEntity['id'];
+      vaultId: VaultEntity['id']; // source vault — needed by crossChainRecoveryExecuteOrder for tx metadata
       bridgedAmount: BigNumber;
       bridgeToken: TokenErc20;
       desiredOutput: TokenEntity;
+      destChainHelpers: ChainTransactHelpers;
     },
     t: TFunction<Namespace>
   ): Promise<Step> {
-    const { swapAggregator, getState } = this.helpers;
+    const { swapAggregator, getState, zap: destZap } = params.destChainHelpers;
     const state = getState();
     const { opId, destChainId, vaultId, bridgedAmount, bridgeToken, desiredOutput } = params;
     const slippage = selectTransactSlippage(state);
@@ -1254,7 +1248,6 @@ class CrossChainStrategyImpl implements IZapStrategy<StrategyId> {
         fromToken: bridgeToken,
         fromAmount: bridgedAmount,
         toToken: desiredOutput,
-        vaultId,
       },
       state,
       this.options.swap
@@ -1263,11 +1256,6 @@ class CrossChainStrategyImpl implements IZapStrategy<StrategyId> {
       throw new Error('No swap quotes available for recovery');
     }
     const bestSwap = destSwapQuotes[0];
-
-    const destZap = selectZapByChainId(state, destChainId);
-    if (!destZap) {
-      throw new Error(`No zap router on chain ${destChainId}`);
-    }
 
     // 2. Build ZapSteps for the swap
     const swapZap = await fetchZapAggregatorSwap(

--- a/src/features/data/apis/transact/swap/ISwapAggregator.ts
+++ b/src/features/data/apis/transact/swap/ISwapAggregator.ts
@@ -34,7 +34,7 @@ export interface ISwapAggregator {
    */
   fetchTokenSupport(
     tokens: TokenEntity[],
-    vaultId: VaultEntity['id'],
+    vaultId: VaultEntity['id'] | undefined,
     chainId: ChainEntity['id'],
     state: BeefyState,
     options?: StrategySwapConfig

--- a/src/features/data/apis/transact/swap/ISwapProvider.ts
+++ b/src/features/data/apis/transact/swap/ISwapProvider.ts
@@ -9,7 +9,7 @@ export type QuoteRequest = {
   fromToken: TokenEntity;
   fromAmount: BigNumber;
   toToken: TokenEntity;
-  vaultId: VaultEntity['id']; // so we can block vaults from aggregators if needed
+  vaultId?: VaultEntity['id']; // so we can block vaults from aggregators if needed
 };
 
 export type QuoteResponse<T = unknown> = {
@@ -50,7 +50,7 @@ export type SwapResponse = {
 export interface ISwapProvider {
   getId(): string;
   getSupportedTokens(
-    vaultId: VaultEntity['id'],
+    vaultId: VaultEntity['id'] | undefined,
     chainId: ChainEntity['id'],
     state: BeefyState
   ): Promise<TokenEntity[]>;

--- a/src/features/data/apis/transact/swap/SwapAggregator.ts
+++ b/src/features/data/apis/transact/swap/SwapAggregator.ts
@@ -54,7 +54,7 @@ export class SwapAggregator implements ISwapAggregator {
 
   protected async providerSupportedTokens(
     provider: ISwapProvider,
-    vaultId: VaultEntity['id'],
+    vaultId: VaultEntity['id'] | undefined,
     chainId: ChainEntity['id'],
     state: BeefyState,
     options: StrategySwapConfig | undefined
@@ -70,7 +70,7 @@ export class SwapAggregator implements ISwapAggregator {
 
   async fetchTokenSupport(
     wantedTokens: TokenEntity[],
-    vaultId: VaultEntity['id'],
+    vaultId: VaultEntity['id'] | undefined,
     chainId: ChainEntity['id'],
     state: BeefyState,
     options?: StrategySwapConfig
@@ -143,7 +143,7 @@ export class SwapAggregator implements ISwapAggregator {
 
   protected async canSwapBetween(
     provider: ISwapProvider,
-    vaultId: VaultEntity['id'],
+    vaultId: VaultEntity['id'] | undefined,
     tokenA: TokenEntity,
     tokenB: TokenEntity,
     state: BeefyState,

--- a/src/features/data/apis/transact/swap/kyber/KyberSwapProvider.ts
+++ b/src/features/data/apis/transact/swap/kyber/KyberSwapProvider.ts
@@ -117,7 +117,7 @@ export class KyberSwapProvider implements ISwapProvider {
   }
 
   async getSupportedTokens(
-    vaultId: VaultEntity['id'],
+    vaultId: VaultEntity['id'] | undefined,
     chainId: ChainEntity['id'],
     state: BeefyState
   ): Promise<TokenEntity[]> {
@@ -126,7 +126,7 @@ export class KyberSwapProvider implements ISwapProvider {
       return [];
     }
 
-    if (config.blockedVaults.includes(vaultId)) {
+    if (vaultId && config.blockedVaults.includes(vaultId)) {
       return [];
     }
 

--- a/src/features/data/apis/transact/swap/liquid-swap/LiquidSwapSwapProvider.ts
+++ b/src/features/data/apis/transact/swap/liquid-swap/LiquidSwapSwapProvider.ts
@@ -115,7 +115,7 @@ export class LiquidSwapSwapProvider implements ISwapProvider {
   }
 
   async getSupportedTokens(
-    vaultId: VaultEntity['id'],
+    vaultId: VaultEntity['id'] | undefined,
     chainId: ChainEntity['id'],
     state: BeefyState
   ): Promise<TokenEntity[]> {
@@ -124,7 +124,7 @@ export class LiquidSwapSwapProvider implements ISwapProvider {
       return [];
     }
 
-    if (config.blockedVaults.includes(vaultId)) {
+    if (vaultId && config.blockedVaults.includes(vaultId)) {
       return [];
     }
 

--- a/src/features/data/apis/transact/swap/one-inch/OneInchSwapProvider.ts
+++ b/src/features/data/apis/transact/swap/one-inch/OneInchSwapProvider.ts
@@ -101,7 +101,7 @@ export class OneInchSwapProvider implements ISwapProvider {
   }
 
   async getSupportedTokens(
-    vaultId: VaultEntity['id'],
+    vaultId: VaultEntity['id'] | undefined,
     chainId: ChainEntity['id'],
     state: BeefyState
   ): Promise<TokenEntity[]> {
@@ -110,7 +110,7 @@ export class OneInchSwapProvider implements ISwapProvider {
       return [];
     }
 
-    if (config.blockedVaults.includes(vaultId)) {
+    if (vaultId && config.blockedVaults.includes(vaultId)) {
       return [];
     }
 

--- a/src/features/data/apis/transact/swap/wnative/WNativeSwapProvider.ts
+++ b/src/features/data/apis/transact/swap/wnative/WNativeSwapProvider.ts
@@ -64,7 +64,7 @@ export class WNativeSwapProvider implements ISwapProvider {
   }
 
   async getSupportedTokens(
-    _vaultId: VaultEntity['id'],
+    _vaultId: VaultEntity['id'] | undefined,
     chainId: ChainEntity['id'],
     state: BeefyState
   ): Promise<TokenEntity[]> {

--- a/src/features/data/apis/transact/transact-types.ts
+++ b/src/features/data/apis/transact/transact-types.ts
@@ -15,7 +15,7 @@ import type { CrossChainRecoveryParams } from '../../reducers/wallet/transact-ty
 import type { BeefyStateFn } from '../../store/types.ts';
 import type { CurveTokenOption } from './strategies/curve/types.ts';
 import type { ZapStrategyId } from './strategies/strategy-configs.ts';
-import type { IStrategy, TransactHelpers, ZapTransactHelpers } from './strategies/IStrategy.ts';
+import type { ChainTransactHelpers, IStrategy, TransactHelpers } from './strategies/IStrategy.ts';
 import type { QuoteResponse } from './swap/ISwapProvider.ts';
 import type { CCTPBridgeQuote } from './cctp/types.ts';
 
@@ -1065,16 +1065,18 @@ export interface ITransactApi {
 
   getHelpersForChain(
     chainId: ChainEntity['id'],
-    vaultId: VaultEntity['id'],
     getState: BeefyStateFn
-  ): Promise<ZapTransactHelpers>;
+  ): Promise<ChainTransactHelpers>;
+
+  getHelpersForVault(vaultId: VaultEntity['id'], getState: BeefyStateFn): Promise<TransactHelpers>;
 
   getZapStrategiesForVault(helpers: TransactHelpers): Promise<IStrategy[]>;
 
   fetchRecoveryQuote(
     recoveryParams: CrossChainRecoveryParams,
     actualBridgedAmount: BigNumber,
-    getState: BeefyStateFn
+    getState: BeefyStateFn,
+    sourceVaultId: VaultEntity['id']
   ): Promise<RecoveryQuote>;
 
   fetchRecoveryStep(
@@ -1082,6 +1084,7 @@ export interface ITransactApi {
     opId: string,
     actualBridgedAmount: BigNumber,
     getState: BeefyStateFn,
-    t: TFunction<Namespace>
+    t: TFunction<Namespace>,
+    sourceVaultId: VaultEntity['id']
   ): Promise<Step>;
 }

--- a/src/features/data/apis/transact/transact.ts
+++ b/src/features/data/apis/transact/transact.ts
@@ -21,6 +21,7 @@ import {
   type IStrategy,
   isComposableStrategy,
   isZapTransactHelpers,
+  type ChainTransactHelpers,
   type IZapStrategyStatic,
   type TransactHelpers,
   type ZapTransactHelpers,
@@ -85,39 +86,29 @@ export function isComposableStrategyConstructorWithOptions(
 
 export class TransactApi implements ITransactApi {
   /**
-   * Get transact helpers for a vault on a specific chain.
-   * Used by CrossChainStrategy for destination chain operations.
+   * Get chain-level transact helpers (no vault context).
    * Guarantees zap router exists (throws otherwise).
    */
   async getHelpersForChain(
     chainId: ChainEntity['id'],
-    vaultId: VaultEntity['id'],
     getState: BeefyStateFn
-  ): Promise<ZapTransactHelpers> {
+  ): Promise<ChainTransactHelpers> {
     const state = getState();
     const zap = selectZapByChainId(state, chainId);
     if (!zap) {
       throw new Error(`No zap router configured for chain ${chainId}`);
     }
 
-    const vault = selectVaultById(state, vaultId);
-    if (vault.chainId !== chainId) {
-      throw new Error(`Vault ${vaultId} is on chain ${vault.chainId}, not ${chainId}`);
-    }
-
-    const vaultType = await this.getVaultTypeFor(vault, getState);
     const swapAggregator = await getSwapAggregator();
 
     return {
-      vault,
-      vaultType,
       zap,
       swapAggregator,
       getState,
     };
   }
 
-  protected async getHelpersForVault(
+  async getHelpersForVault(
     vaultId: VaultEntity['id'],
     getState: BeefyStateFn
   ): Promise<TransactHelpers> {
@@ -626,14 +617,10 @@ export class TransactApi implements ITransactApi {
   async fetchRecoveryQuote(
     recoveryParams: CrossChainRecoveryParams,
     actualBridgedAmount: BigNumber,
-    getState: BeefyStateFn
+    getState: BeefyStateFn,
+    sourceVaultId: VaultEntity['id']
   ): Promise<RecoveryQuote> {
-    const { destChainId, vaultId } = recoveryParams;
-
-    const helpers = await this.getHelpersForChain(destChainId, vaultId, getState);
-
-    const xChainStrategy = new CrossChainStrategy({ strategyId: 'cross-chain' }, helpers);
-
+    const { destChainId } = recoveryParams;
     const state = getState();
     const bridgeToken = selectTokenByAddress(
       state,
@@ -641,10 +628,17 @@ export class TransactApi implements ITransactApi {
       recoveryParams.bridgeTokenAddress
     ) as TokenErc20;
 
+    // Always instantiate strategy with the original source vault helpers
+    const helpers = await this.getHelpersForVault(sourceVaultId, getState);
+    if (!isZapTransactHelpers(helpers)) {
+      throw new Error(`No zap router configured for vault ${sourceVaultId}`);
+    }
+    const xChainStrategy = new CrossChainStrategy({ strategyId: 'cross-chain' }, helpers);
+
     if (recoveryParams.direction === 'deposit') {
       return xChainStrategy.fetchDestinationDepositQuote({
         destChainId,
-        vaultId,
+        vaultId: recoveryParams.vaultId,
         bridgedAmount: actualBridgedAmount,
         bridgeToken,
       });
@@ -652,6 +646,7 @@ export class TransactApi implements ITransactApi {
       if (!recoveryParams.desiredOutputAddress) {
         throw new Error('No recovery quote needed for USDC-output withdrawals');
       }
+      const destChainHelpers = await this.getHelpersForChain(destChainId, getState);
       const desiredOutput = selectTokenByAddress(
         state,
         destChainId,
@@ -659,10 +654,10 @@ export class TransactApi implements ITransactApi {
       );
       return xChainStrategy.fetchDestinationWithdrawQuote({
         destChainId,
-        vaultId,
         bridgedAmount: actualBridgedAmount,
         bridgeToken,
         desiredOutput,
+        destChainHelpers,
       });
     }
   }
@@ -672,14 +667,10 @@ export class TransactApi implements ITransactApi {
     opId: string,
     actualBridgedAmount: BigNumber,
     getState: BeefyStateFn,
-    t: TFunction<Namespace>
+    t: TFunction<Namespace>,
+    sourceVaultId: VaultEntity['id']
   ): Promise<Step> {
-    const { destChainId, vaultId } = recoveryParams;
-
-    const helpers = await this.getHelpersForChain(destChainId, vaultId, getState);
-
-    const xChainStrategy = new CrossChainStrategy({ strategyId: 'cross-chain' }, helpers);
-
+    const { destChainId } = recoveryParams;
     const state = getState();
     const bridgeToken = selectTokenByAddress(
       state,
@@ -687,15 +678,29 @@ export class TransactApi implements ITransactApi {
       recoveryParams.bridgeTokenAddress
     ) as TokenErc20;
 
+    // Always instantiate strategy with the original source vault helpers
+    const helpers = await this.getHelpersForVault(sourceVaultId, getState);
+    if (!isZapTransactHelpers(helpers)) {
+      throw new Error(`No zap router configured for vault ${sourceVaultId}`);
+    }
+    const xChainStrategy = new CrossChainStrategy({ strategyId: 'cross-chain' }, helpers);
+
     if (recoveryParams.direction === 'deposit') {
       return xChainStrategy.fetchDestinationDepositStep(
-        { opId, destChainId, vaultId, bridgedAmount: actualBridgedAmount, bridgeToken },
+        {
+          opId,
+          destChainId,
+          vaultId: recoveryParams.vaultId,
+          bridgedAmount: actualBridgedAmount,
+          bridgeToken,
+        },
         t
       );
     } else {
       if (!recoveryParams.desiredOutputAddress) {
         throw new Error('No recovery step needed for USDC-output withdrawals');
       }
+      const destChainHelpers = await this.getHelpersForChain(destChainId, getState);
       const desiredOutput = selectTokenByAddress(
         state,
         destChainId,
@@ -705,10 +710,11 @@ export class TransactApi implements ITransactApi {
         {
           opId,
           destChainId,
-          vaultId,
+          vaultId: sourceVaultId,
           bridgedAmount: actualBridgedAmount,
           bridgeToken,
           desiredOutput,
+          destChainHelpers,
         },
         t
       );

--- a/src/features/data/reducers/wallet/transact-types.ts
+++ b/src/features/data/reducers/wallet/transact-types.ts
@@ -94,7 +94,6 @@ export type CrossChainDepositRecoveryParams = {
 export type CrossChainWithdrawRecoveryParams = {
   direction: 'withdraw';
   destChainId: ChainEntity['id'];
-  vaultId: VaultEntity['id'];
   bridgeTokenAddress: string;
   bridgedAmount: string;
   desiredOutputAddress?: string;

--- a/src/features/data/selectors/transact.ts
+++ b/src/features/data/selectors/transact.ts
@@ -554,7 +554,7 @@ export const selectRecoveryOpForCurrentVault = createSelector(
   [(state: BeefyState) => state.ui.transact.vaultId, selectCrossChainRecoverableOps],
   (vaultId, recoverableOps): PendingCrossChainOp | undefined => {
     if (!vaultId) return undefined;
-    const forVault = recoverableOps.filter(op => op.recovery.vaultId === vaultId);
+    const forVault = recoverableOps.filter(op => op.vaultId === vaultId);
     if (forVault.length === 0) return undefined;
     return orderBy(forVault, 'updatedAt', 'desc')[0];
   }


### PR DESCRIPTION
## Summary

Fixes cross-chain withdrawal recovery failing with "Vault X is on chain base, not optimism" when the destination swap fails and the user tries to refresh the quote.

- Recovery op data no longer contains vaultId for withdrawals. It's a vault agnostic flow, just a swap is missing
- Adjusted Provider/Aggregator interface so quotes can be fetched without a vault being needed
- CrossChainStrategy is created using original params every time but if on withdrawal vault-agnostic helpers are used for recovery
