### PR TITLE
fix: align chain and token list spacing in transact select screens

### DIFF
--- a/src/features/vault/components/Actions/Transact/ChainSelectStep/ChainSelectStep.tsx
+++ b/src/features/vault/components/Actions/Transact/ChainSelectStep/ChainSelectStep.tsx
@@ -89,7 +89,7 @@ const ChainList = memo(function ChainList() {
         <SearchInput value={search} onValueChange={setSearch} />
       </SelectListSearch>
       <Scrollable css={selectListScrollable}>
-        <SelectListItems>
+        <SelectListItems noGap={true}>
           {filteredChains.length ?
             filteredChains.map(({ chainId, chainName, balanceUsd, tokens }) => (
               <ChainListRow
@@ -175,6 +175,7 @@ const ChainRowButton = styled('button', {
     alignItems: 'center',
     columnGap: '16px',
     width: '100%',
+    height: '44px',
     color: 'text.dark',
     background: 'transparent',
     border: 'none',

--- a/src/features/vault/components/Actions/Transact/common/CommonListStyles.tsx
+++ b/src/features/vault/components/Actions/Transact/common/CommonListStyles.tsx
@@ -147,6 +147,7 @@ export const ListItemBalanceUsd = styled('span', {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
+    lineHeight: '1',
   },
 });
 

--- a/src/features/vault/components/Actions/Transact/common/CommonListStyles.tsx
+++ b/src/features/vault/components/Actions/Transact/common/CommonListStyles.tsx
@@ -18,10 +18,9 @@ export const SelectListContainer = styled('div', {
 export const SelectListSearch = styled('div', {
   base: {
     padding: '0 16px',
-    margin: '0 0 16px 0',
+    margin: '0 0 12px 0',
     sm: {
       padding: '0 24px',
-      margin: '0 0 24px 0',
     },
   },
 });


### PR DESCRIPTION
## Summary
- Standardize chain select list to use the same `noGap` + fixed `44px` item height approach as the token select list
- Reduce search-to-list gap from 16px/24px to 12px to match Figma spec
- Remove redundant `sm` margin override in `SelectListSearch`

## Test plan
- [x] Open a vault with cross-chain deposit support
- [x] Verify "Select chain to deposit from" list spacing matches "Select token to deposit"
- [x] Verify 12px gap between search box and first list item on both screens
- [x] Check both mobile and desktop breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)