### PR TITLE
fix(cctp): restore retry and Close CTAs in cross-chain recovery flow

### DIFF
--- a/src/components/Stepper/components/Content/Content.tsx
+++ b/src/components/Stepper/components/Content/Content.tsx
@@ -45,6 +45,7 @@ import {
 import {
   selectCrossChainRecoveryQuoteOpId,
   selectCrossChainRecoveryQuoteStatus,
+  selectRecoveryOpForCurrentVault,
   selectTransactExecuting,
   selectTransactMode,
 } from '../../../../features/data/selectors/transact.ts';
@@ -121,7 +122,40 @@ export const WaitingContent = memo(function WaitingContent() {
 export const ErrorContent = memo(function ErrorContent() {
   const { t } = useTranslation();
   const classes = useStyles();
+  const dispatch = useAppDispatch();
   const walletActionsState = useAppSelector(state => state.user.walletActions);
+
+  // Recovery-aware retry: when a CCTP recovery zap fails (cancel or revert),
+  // offer a context-appropriate retry button alongside Close so the user
+  // can stay in the recovery flow without dismissing the error first.
+  const isRecoveryExecution = useAppSelector(selectIsStepperRecoveryExecution);
+  const recoveryOp = useAppSelector(selectRecoveryOpForCurrentVault);
+  const bridgeStatus = useAppSelector(selectStepperBridgeStatus);
+  const recoveryQuoteStatus = useAppSelector(selectCrossChainRecoveryQuoteStatus);
+  const recoveryQuoteOpId = useAppSelector(selectCrossChainRecoveryQuoteOpId);
+  const isExecuting = useAppSelector(selectTransactExecuting);
+  const mode = useAppSelector(selectTransactMode);
+
+  const isRecovery = isRecoveryExecution || recoveryOp != null;
+  const opIdFromOp = bridgeStatus?.opId ?? recoveryOp?.id;
+  const opId = opIdFromOp ?? recoveryQuoteOpId;
+  const hasValidQuote =
+    opId != null && recoveryQuoteOpId === opId && recoveryQuoteStatus === TransactStatus.Fulfilled;
+  const isFetchingQuote = recoveryQuoteStatus === TransactStatus.Pending;
+  const finaliseNoun = mode === TransactMode.Withdraw ? t('Withdraw-noun') : t('Deposit-noun');
+
+  const handleFinalise = useCallback(() => {
+    if (opId) {
+      dispatch(crossChainRecoverySteps(opId, t));
+    }
+  }, [dispatch, opId, t]);
+
+  const handleFetchQuote = useCallback(() => {
+    if (opId) {
+      dispatch(crossChainFetchRecoveryQuote({ opId }));
+    }
+  }, [dispatch, opId]);
+
   const handleSelectAll = useCallback<MouseEventHandler<HTMLDivElement>>(e => {
     if (e.target instanceof HTMLElement && window.getSelection) {
       const selection = window.getSelection();
@@ -133,6 +167,35 @@ export const ErrorContent = memo(function ErrorContent() {
 
   if (!isWalletActionError(walletActionsState)) {
     return null;
+  }
+
+  let recoveryRetryButton: ReactNode = null;
+  if (isRecovery && opId) {
+    if (hasValidQuote) {
+      recoveryRetryButton = (
+        <Button
+          variant="recovery"
+          fullWidth={true}
+          borderless={true}
+          disabled={isExecuting}
+          onClick={handleFinalise}
+        >
+          {t('Transact-Finalise', { type: finaliseNoun })}
+        </Button>
+      );
+    } else {
+      recoveryRetryButton = (
+        <Button
+          variant="recovery"
+          fullWidth={true}
+          borderless={true}
+          disabled={isFetchingQuote || isExecuting}
+          onClick={handleFetchQuote}
+        >
+          {isFetchingQuote ? t('Transact-FetchingQuote') : t('Transact-FetchNewQuote')}
+        </Button>
+      );
+    }
   }
 
   return (
@@ -156,7 +219,10 @@ export const ErrorContent = memo(function ErrorContent() {
           {walletActionsState.data.error.message}
         </div>
       </div>
-      <div className={classes.buttons}>
+      <div
+        className={cx(classes.buttons, recoveryRetryButton ? classes.buttonsRetryClose : undefined)}
+      >
+        {recoveryRetryButton}
         <CloseButton />
       </div>
     </>

--- a/src/components/Stepper/components/Content/styles.ts
+++ b/src/components/Stepper/components/Content/styles.ts
@@ -72,6 +72,12 @@ export const styles = {
       height: '44px',
     },
   }),
+  // Variant for the recovery error state: primary retry button takes all
+  // remaining space, Close button is compact (natural width).
+  buttonsRetryClose: css.raw({
+    gridAutoColumns: 'unset',
+    gridTemplateColumns: '1fr auto',
+  }),
   link: css.raw({
     textDecoration: 'none',
     color: 'green.80-40',

--- a/src/features/vault/components/Actions/Transact/CommonActions/ActionRecovery.tsx
+++ b/src/features/vault/components/Actions/Transact/CommonActions/ActionRecovery.tsx
@@ -7,17 +7,25 @@ import {
   crossChainFetchRecoveryQuote,
   crossChainRecoverySteps,
 } from '../../../../../data/actions/wallet/cross-chain.ts';
+import { stepperReset } from '../../../../../data/actions/wallet/stepper.ts';
+import {
+  transactClearInput,
+  transactSetSuccessClosed,
+} from '../../../../../data/actions/transact.ts';
+import { StepContent } from '../../../../../data/reducers/wallet/stepper-types.ts';
 import { TransactStatus } from '../../../../../data/reducers/wallet/transact-types.ts';
 import {
   selectIsStepperRecoveryExecution,
   selectIsStepperStepping,
   selectStepperBridgeStatus,
+  selectStepperStepContent,
 } from '../../../../../data/selectors/stepper.ts';
 import {
   selectCrossChainRecoveryQuoteOpId,
   selectCrossChainRecoveryQuoteStatus,
   selectRecoveryOpForCurrentVault,
   selectTransactExecuting,
+  selectTransactSuccessClosed,
   selectTransactVaultId,
 } from '../../../../../data/selectors/transact.ts';
 import { selectVaultById } from '../../../../../data/selectors/vaults.ts';
@@ -45,12 +53,17 @@ export const ActionRecovery = memo(function ActionRecovery({ mode }: ActionRecov
   const connectedChainId = useAppSelector(selectCurrentChainId);
   const isTxInProgress = useAppSelector(selectIsStepperStepping);
   const isRecoveryExecution = useAppSelector(selectIsStepperRecoveryExecution);
+  const stepperContent = useAppSelector(selectStepperStepContent);
   const recoveryQuoteStatus = useAppSelector(selectCrossChainRecoveryQuoteStatus);
   const recoveryQuoteOpId = useAppSelector(selectCrossChainRecoveryQuoteOpId);
   const isExecuting = useAppSelector(selectTransactExecuting);
+  const successClosed = useAppSelector(selectTransactSuccessClosed);
 
   const vaultId = useAppSelector(selectTransactVaultId);
   const vault = useAppSelector(state => selectVaultById(state, vaultId));
+
+  const isSuccessTx = stepperContent === StepContent.SuccessTx;
+  const isComplete = successClosed || isSuccessTx;
 
   const opIdFromOp = bridgeStatus?.opId ?? recoveryOp?.id;
   const opId = opIdFromOp ?? recoveryQuoteOpId;
@@ -81,6 +94,33 @@ export const ActionRecovery = memo(function ActionRecovery({ mode }: ActionRecov
       dispatch(crossChainRecoverySteps(opId, t));
     }
   }, [dispatch, opId, t]);
+
+  const handleClose = useCallback(() => {
+    dispatch(transactSetSuccessClosed(false));
+    dispatch(transactClearInput());
+    dispatch(stepperReset());
+  }, [dispatch]);
+
+  // After a successful recovery the stepper transitions to SuccessTx but
+  // isRecoveryExecution stays true until stepperReset, which keeps this
+  // component mounted. Short-circuit to a Close + success animation so the
+  // form matches the stepper's success state.
+  if (isComplete) {
+    return (
+      <div className={classes.feesContainer}>
+        <AnimatedButton
+          variant="cta"
+          isConfirmed={true}
+          fullWidth={true}
+          borderless={true}
+          onClick={handleClose}
+        >
+          {t('Transactn-Close')}
+        </AnimatedButton>
+        <VaultFees />
+      </div>
+    );
+  }
 
   if (isUnknownFailure) {
     return (

--- a/src/features/vault/components/Actions/Transact/CommonActions/ActionRecovery.tsx
+++ b/src/features/vault/components/Actions/Transact/CommonActions/ActionRecovery.tsx
@@ -15,7 +15,6 @@ import {
 import { StepContent } from '../../../../../data/reducers/wallet/stepper-types.ts';
 import { TransactStatus } from '../../../../../data/reducers/wallet/transact-types.ts';
 import {
-  selectIsStepperRecoveryExecution,
   selectIsStepperStepping,
   selectStepperBridgeStatus,
   selectStepperStepContent,
@@ -52,7 +51,6 @@ export const ActionRecovery = memo(function ActionRecovery({ mode }: ActionRecov
   const isWalletConnected = useAppSelector(selectIsWalletConnected);
   const connectedChainId = useAppSelector(selectCurrentChainId);
   const isTxInProgress = useAppSelector(selectIsStepperStepping);
-  const isRecoveryExecution = useAppSelector(selectIsStepperRecoveryExecution);
   const stepperContent = useAppSelector(selectStepperStepContent);
   const recoveryQuoteStatus = useAppSelector(selectCrossChainRecoveryQuoteStatus);
   const recoveryQuoteOpId = useAppSelector(selectCrossChainRecoveryQuoteOpId);
@@ -64,6 +62,7 @@ export const ActionRecovery = memo(function ActionRecovery({ mode }: ActionRecov
 
   const isSuccessTx = stepperContent === StepContent.SuccessTx;
   const isComplete = successClosed || isSuccessTx;
+  const isStepperError = stepperContent === StepContent.ErrorTx;
 
   const opIdFromOp = bridgeStatus?.opId ?? recoveryOp?.id;
   const opId = opIdFromOp ?? recoveryQuoteOpId;
@@ -75,7 +74,11 @@ export const ActionRecovery = memo(function ActionRecovery({ mode }: ActionRecov
   const hasValidQuote =
     opId != null && recoveryQuoteOpId === opId && recoveryQuoteStatus === TransactStatus.Fulfilled;
 
-  const needsNewQuote = recoveryOp != null && !isRecoveryExecution && !hasValidQuote;
+  // A recovery tx is considered "in flight" while the stepper is actively
+  // running it. ErrorTx is explicitly excluded so the form CTA stays usable
+  // alongside the stepper's retry button after a failed attempt.
+  const isRecoveryInFlight = isTxInProgress && !isStepperError;
+  const needsNewQuote = recoveryOp != null && !isRecoveryInFlight && !hasValidQuote;
 
   const isUnknownFailure =
     bridgeStatus?.lifecycleState === 'abandoned' &&
@@ -168,7 +171,7 @@ export const ActionRecovery = memo(function ActionRecovery({ mode }: ActionRecov
         <AnimatedButton
           needFire={true}
           variant="recovery"
-          disabled={isTxInProgress || isFetchingQuote || !opId}
+          disabled={isRecoveryInFlight || isFetchingQuote || !opId}
           fullWidth={true}
           borderless={true}
           onClick={handleFetchQuote}
@@ -181,7 +184,7 @@ export const ActionRecovery = memo(function ActionRecovery({ mode }: ActionRecov
   }
 
   const canFinalise = hasValidQuote && opId != null;
-  const finaliseDisabled = !canFinalise || isTxInProgress || isExecuting;
+  const finaliseDisabled = !canFinalise || isRecoveryInFlight || isExecuting;
 
   return (
     <div className={classes.feesContainer}>


### PR DESCRIPTION
## Summary

Fixes two related UI issues in the CCTP cross-chain recovery flow that made it awkward to recover from a failed or successful recovery zap.

### 1. Successful recovery left the form stuck on "Finalise withdrawal"

After a successful cross-chain recovery, the stepper modal correctly showed the success notification, but the form-level Deposit/Withdraw module still showed the "Finalise" button instead of transitioning to "Close" + success animation like the regular non-recovery flow does. Clicking it did nothing useful.

**Fix:** Added an `isComplete` short-circuit at the top of `ActionRecovery` that renders an `AnimatedButton` with `isConfirmed={true}` and a handler matching the regular `ActionDeposit` / `ActionWithdraw` pattern.

### 2. Failed recovery offered no way to retry from the stepper

After a failed recovery (either user cancelled in the wallet or the tx reverted on chain), the stepper showed a generic `[Close]`-only error screen. The user had to dismiss the stepper before they could retry from the form. Worse, the form-level Finalise button was disabled while the stepper was in the error state — `selectIsStepperStepping` counts `ErrorTx` as "stepping", so `isTxInProgress` was true in `ActionRecovery`. Both surfaces ended up telling the user different things simultaneously.

**Fix:**

- **Stepper:** `ErrorContent` is now recovery-aware. When there's an active recovery op, it renders a `[Finalise withdrawal]` button next to `[Close]` when the cached quote is still valid, or `[Refresh quote]` when it's stale. A new `buttonsRetryClose` style variant lets the primary retry button flex while Close stays compact.
- **Form:** A new `isRecoveryInFlight` flag in `ActionRecovery` (which treats `ErrorTx` as "not in progress") drives both the `needsNewQuote` gate and the disabled state on the Finalise and Refresh buttons, so both surfaces stay in sync during the error state.

## Files changed

- `src/features/vault/components/Actions/Transact/CommonActions/ActionRecovery.tsx` — success short-circuit + `isRecoveryInFlight` gates
- `src/components/Stepper/components/Content/Content.tsx` — recovery-aware `ErrorContent` with retry button
- `src/components/Stepper/components/Content/styles.ts` — `buttonsRetryClose` variant for the asymmetric button layout

Affects both cross-chain deposit and withdraw recovery flows equally (they share the same `ActionRecovery` component). Manual testing was done against the withdraw path; the deposit path uses the same code and is covered by the same fix.

## Test plan

Tested locally with forced-failure patches that make the destination receiver hook revert (entering the recovery flow) and the first recovery finalise revert (triggering the error state). All validated end-to-end:

- [x] **Failed recovery — on-chain revert.** Stepper shows `[Finalise withdrawal][Close]`, form Finalise stays enabled. Retrying from either surface re-dispatches `crossChainRecoverySteps` and cycles back through the tx flow cleanly.
- [x] **Failed recovery — user cancellation in wallet.** Same two-button layout, different error message ("User rejected the request"). Retry works from both surfaces.
- [x] **Stepper retry ↔ form retry parity.** Clicked Finalise from stepper, cancelled, clicked Finalise from form, signed, reverted, then alternated — no state bleed, both surfaces stay in sync.
- [x] **Stale quote path.** Manually cleared `recoveryQuote` → both stepper and form transitioned from `[Finalise]` to `[Refresh quote]`, both enabled. Clicked Refresh from either surface → both showed "Refreshing quote..." → both returned to `[Finalise]` after fresh quote loaded.
- [x] **Successful recovery.** Recovery zap mined successfully → stepper shows success notification, form shows `[Close]` with the cow success animation (not stuck on Finalise). Click Close from either surface resets cleanly.
- [x] **Happy path without forced failures.** Regular cross-chain withdraw works end-to-end, no recovery flow triggered, no regression.

## Notes for reviewers

- **Behavior for wallet cancellations is unchanged:** the user still lands on the stepper error screen explicitly, they just now have a retry button next to Close.
- **The disabled guards on the new retry buttons match the existing `RecoveryContent` pattern** (`isExecuting` on the Finalise button, `isFetchingQuote || isExecuting` on the Refresh button). No `isTxInProgress` check, because in `ErrorContent` that would be permanently true.
- **No changes to `bindTransactionEvents`, `crossChainRecoveryExecuteOrder`, or the CCTP polling flow.** The fix is purely UI-layer.
- **Gov vault cross-chain recovery is out of scope** and not touched — `WithdrawActionsGov` uses a separate code path.
- Affects both cross-chain deposit and withdraw recovery flows equally (they share the same `ActionRecovery` component). Manual testing was done against the withdraw path; the deposit path uses the same code and is covered by the same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)