### PR TITLE
fix(layout): align dashboard and home header elements

### DIFF
--- a/src/components/Banners/UnstakedClmBanner/UnstakedClmBannerDashboard.tsx
+++ b/src/components/Banners/UnstakedClmBanner/UnstakedClmBannerDashboard.tsx
@@ -1,5 +1,5 @@
-import { css } from '@repo/styles/css';
 import { memo } from 'react';
+import { styled } from '@repo/styles/jsx';
 import { selectUserUnstakedClms } from '../../../features/data/selectors/balance.ts';
 import { useAppSelector } from '../../../features/data/store/hooks.ts';
 import { Container } from '../../Container/Container.tsx';
@@ -15,11 +15,26 @@ export const UnstakedClmBannerDashboard = memo<UnstakedClmBannerDashboardProps>(
     }
 
     return (
-      <div className={css({ backgroundColor: 'background.header' })}>
-        <Container maxWidth="lg">
+      <BannerWrapper>
+        <BannerContainer maxWidth="lg">
           <UnstakedClmBanner />
-        </Container>
-      </div>
+        </BannerContainer>
+      </BannerWrapper>
     );
   }
 );
+
+const BannerWrapper = styled('div', {
+  base: {
+    backgroundColor: 'background.header',
+    paddingBottom: '24px',
+  },
+});
+
+const BannerContainer = styled(Container, {
+  base: {
+    lg: {
+      paddingInline: '26px',
+    },
+  },
+});

--- a/src/features/dashboard/components/UserVaults/components/VaultTransactions/VaultTransactions.tsx
+++ b/src/features/dashboard/components/UserVaults/components/VaultTransactions/VaultTransactions.tsx
@@ -18,6 +18,8 @@ const useStyles = legacyMakeStyles({
     display: 'grid',
     gridTemplateColumns: 'minmax(0, 1fr)',
     rowGap: '2px',
+    borderRadius: '8px',
+    overflow: 'hidden',
   }),
 });
 

--- a/src/features/home/HomePage.tsx
+++ b/src/features/home/HomePage.tsx
@@ -56,14 +56,8 @@ const HomePage = memo(function HomePage() {
 
 const HeaderContainer = styled(Container, {
   base: {
-    // base padding is 12px
-    sm: {
-      //  need to ad 12px for desktop
-      paddingInline: `24px`,
-    },
     lg: {
-      //  need to ad 14px for desktop
-      paddingInline: `26px`,
+      paddingInline: '26px',
     },
   },
 });

--- a/src/features/home/components/Banners/Banners.tsx
+++ b/src/features/home/components/Banners/Banners.tsx
@@ -19,9 +19,6 @@ const BannerList = styled('div', {
     display: 'flex',
     flexDirection: 'column',
     gap: '12px',
-    sm: {
-      gap: '24px',
-    },
     '& > :last-child': {
       marginBottom: '24px',
     },

--- a/src/features/vault/components/PnLGraph/cowcentrated/components/Footers/Footer.tsx
+++ b/src/features/vault/components/PnLGraph/cowcentrated/components/Footers/Footer.tsx
@@ -117,6 +117,7 @@ export const FeesFooter = memo(function Footer({
         onChange={handleChange}
         noBackground={true}
         noPadding={true}
+        noBorder={true}
         variant="range"
       />
     </div>

--- a/src/features/vault/components/PnLGraph/cowcentrated/styles.ts
+++ b/src/features/vault/components/PnLGraph/cowcentrated/styles.ts
@@ -46,6 +46,7 @@ export const styles = {
   dashboardPnlContainer: css.raw({
     backgroundColor: 'background.content',
     borderRadius: '12px',
+    overflow: 'hidden',
     mdDown: {
       borderRadius: '0px',
     },


### PR DESCRIPTION
## Summary

Aligns the dashboard and home page header sections (banner, title row, tiles) so they share the same horizontal insets across all breakpoints, plus a few small polish fixes for the dashboard charts and transactions table.

### Header alignment (banner/tiles)

| | base | sm (tablet) | lg (desktop) |
|---|---|---|---|
| Home banner / tiles | 12px | 12px | 26px |
| Dashboard banner / tiles | 12px | 12px | 26px |

- **Dashboard banner** (`UnstakedClmBannerDashboard`): `BannerContainer` now sets `lg: paddingInline 26px` to line up with the dashboard tiles below and the home page banner. `BannerWrapper` adds `paddingBottom: 24px` so the gap to the `Header` matches the home page's `marginBottom: 24px` on the last banner.
- **Home page** (`HomePage.tsx`): `HeaderContainer` no longer overrides sm to `24px` — banner/tiles now sit at `12px` at base/sm/md and `26px` at lg, matching the dashboard.
- **Home banners gap**: `BannerList` uses `gap: 12px` at every breakpoint (was 12 base / 24 sm). The `marginBottom: 24px` on the last banner is unchanged.

### Dashboard polish

- **Transactions table** (`VaultTransactions`): added `borderRadius: 8px` + `overflow: hidden` to the grid wrapper so the bottom row's corners are clipped to match the filter header's already-rounded top corners.
- **Compounds chart footer** (`FeesFooter`): `ToggleButtons` gains `noBorder={true}` so it renders the same height as the Position chart's `OverviewFooter`. Affects both dashboard and vault page.
- **Dashboard PnL chart wrapper**: `dashboardPnlContainer` gains `overflow: hidden` so the chart's solid background is clipped to the wrapper's 12px radius — top corners now round properly on the Position and Compounds charts.

## Test plan

- [ ] Home page: verify banner + Platform/Portfolio tiles inset to 12px on tablet and 26px on desktop; banner-to-banner gap is 12px on all sizes
- [ ] Dashboard: verify CLM warning banner is the same width as the deposits/yield tiles below; gap between banner and Header matches the home page
- [ ] Dashboard transactions table: bottom-left/right corners are rounded
- [ ] Dashboard Position vs Compounds chart: footer heights match (no 1-2px difference)
- [ ] Dashboard Position/Compounds charts: top corners are rounded
- [ ] Hover the recharts tooltip near the top-right edge of the dashboard chart to confirm the new `overflow: hidden` doesn't clip the tooltip
- [ ] Treasury page (`/treasury`): verify the DAO tiles still render correctly (unchanged, but `SummaryStats` is shared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)