### PR TITLE
Add 8 x Aerodrome CLMs (Migration); Add Timelock Risk to ZRO

### DIFF
--- a/src/config/vault/arbitrum.json
+++ b/src/config/vault/arbitrum.json
@@ -3848,7 +3848,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -6001,7 +6001,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -6047,7 +6047,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -6093,7 +6093,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -8294,7 +8294,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -8851,7 +8851,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -8895,7 +8895,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -9655,7 +9655,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -9699,7 +9699,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -10449,7 +10449,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -11058,7 +11058,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -11095,7 +11095,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -11132,7 +11132,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -13842,7 +13842,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -14689,7 +14689,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -14730,7 +14730,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -14771,7 +14771,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },

--- a/src/config/vault/base.json
+++ b/src/config/vault/base.json
@@ -1,5 +1,949 @@
 [
   {
+    "id": "aerodrome-cow-base-cbxrp-cbbtc-v2-vault",
+    "name": "cbXRP-cbBTC",
+    "type": "standard",
+    "token": "cbXRP-cbBTC",
+    "tokenAddress": "0x76aB3892C202E1100E8df4c09D4Ac3A07bFA345A",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "earnContractAddress": "0x590Ede3Ba3F48B7B570B74f15A4488dB0424849D",
+    "earnedToken": "mooCowAerodromecbXRP-cbBTCv2",
+    "earnedTokenAddress": "0x590Ede3Ba3F48B7B570B74f15A4488dB0424849D",
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-cbxrp-cbbtc-v2",
+    "status": "active",
+    "createdAt": 1776417718,
+    "platformId": "aerodrome",
+    "assets": ["cbXRP", "cbBTC"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "vault-composer"
+      },
+      {
+        "strategyId": "reward-pool-to-vault"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-cbxrp-cbbtc-v2-rp",
+    "name": "cbXRP-cbBTC Reward Pool",
+    "type": "gov",
+    "version": 2,
+    "token": "cowAerodromecbXRP-cbBTCv2",
+    "tokenAddress": "0x76aB3892C202E1100E8df4c09D4Ac3A07bFA345A",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "earnContractAddress": "0x032f732c7503a538B7b8429D53b65a8c19cC4883",
+    "earnedToken": "rCowAerodromecbXRP-cbBTC",
+    "earnedTokenDecimals": 18,
+    "earnedTokenAddresses": ["0x940181a94A35A4569E4529A3CDfB74e38FD98631"],
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-cbxrp-cbbtc-v2",
+    "status": "active",
+    "createdAt": 1776417717,
+    "platformId": "aerodrome",
+    "assets": ["cbXRP", "cbBTC"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "gov-composer"
+      },
+      {
+        "strategyId": "reward-pool-to-vault"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-cbxrp-cbbtc-v2",
+    "name": "cbXRP-cbBTC",
+    "type": "cowcentrated",
+    "token": "cbXRP-cbBTC aerodrome",
+    "tokenAddress": "0x62916B911F2B64d0e3A3b72472D6f8C08c75DcAA",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "depositTokenAddresses": [
+      "0xcb585250f852C6c6bf90434AB21A00f02833a4af",
+      "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
+    ],
+    "earnContractAddress": "0x76aB3892C202E1100E8df4c09D4Ac3A07bFA345A",
+    "earnedToken": "cowAerodromecbXRP-cbBTCv2",
+    "earnedTokenAddress": "0x76aB3892C202E1100E8df4c09D4Ac3A07bFA345A",
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-cbxrp-cbbtc-v2",
+    "status": "active",
+    "createdAt": 1776417717,
+    "platformId": "beefy",
+    "feeTier": "0.25",
+    "assets": ["cbXRP", "cbBTC"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "cowcentrated"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-weth-cbxrp-v2-vault",
+    "name": "cbXRP-WETH",
+    "type": "standard",
+    "token": "cbXRP-WETH",
+    "tokenAddress": "0x642Df18ba969512Fe0C0E6b9e43Ff23edF419611",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "earnContractAddress": "0x4D01fe6Ee8285db728Aa2856b5AD3D531324a150",
+    "earnedToken": "mooCowAerodromeWETH-cbXRP",
+    "earnedTokenAddress": "0x4D01fe6Ee8285db728Aa2856b5AD3D531324a150",
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-weth-cbxrp-v2",
+    "status": "active",
+    "createdAt": 1776417381,
+    "platformId": "aerodrome",
+    "assets": ["cbXRP", "WETH"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "vault-composer"
+      },
+      {
+        "strategyId": "reward-pool-to-vault"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-weth-cbxrp-v2-rp",
+    "name": "cbXRP-WETH Reward Pool",
+    "type": "gov",
+    "version": 2,
+    "token": "cowAerodromeWETH-cbXRP",
+    "tokenAddress": "0x642Df18ba969512Fe0C0E6b9e43Ff23edF419611",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "earnContractAddress": "0x6de6a6eaa58df4C49AaADb23D20FFA4492BA1075",
+    "earnedToken": "rCowAerodromeWETH-cbXRP",
+    "earnedTokenDecimals": 18,
+    "earnedTokenAddresses": ["0x940181a94A35A4569E4529A3CDfB74e38FD98631"],
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-weth-cbxrp-v2",
+    "status": "active",
+    "createdAt": 1776417380,
+    "platformId": "aerodrome",
+    "assets": ["cbXRP", "WETH"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "gov-composer"
+      },
+      {
+        "strategyId": "reward-pool-to-vault"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-weth-cbxrp-v2",
+    "name": "cbXRP-WETH",
+    "type": "cowcentrated",
+    "token": "cbXRP-WETH aerodrome",
+    "tokenAddress": "0xB90fe999Be6869AF0aFC557DCCfBE169EA3403D6",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "depositTokenAddresses": [
+      "0x4200000000000000000000000000000000000006",
+      "0xcb585250f852C6c6bf90434AB21A00f02833a4af"
+    ],
+    "earnContractAddress": "0x642Df18ba969512Fe0C0E6b9e43Ff23edF419611",
+    "earnedToken": "cowAerodromeWETH-cbXRP",
+    "earnedTokenAddress": "0x642Df18ba969512Fe0C0E6b9e43Ff23edF419611",
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-weth-cbxrp-v2",
+    "status": "active",
+    "createdAt": 1776417380,
+    "platformId": "beefy",
+    "feeTier": "0.05",
+    "assets": ["cbXRP", "WETH"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "cowcentrated"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-sol-cbbtc-vault",
+    "name": "SOL-cbBTC",
+    "type": "standard",
+    "token": "SOL-cbBTC",
+    "tokenAddress": "0x8c4855c5371Cc01f6464c38515914eD42978e0f5",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "earnContractAddress": "0x4CEfEd210D492c06c76E59505f52d0f5111DE2F8",
+    "earnedToken": "mooCowAerodromeSOL-cbBTC",
+    "earnedTokenAddress": "0x4CEfEd210D492c06c76E59505f52d0f5111DE2F8",
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-sol-cbbtc",
+    "status": "active",
+    "createdAt": 1776417110,
+    "platformId": "aerodrome",
+    "assets": ["SOL", "cbBTC"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "vault-composer"
+      },
+      {
+        "strategyId": "reward-pool-to-vault"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-sol-cbbtc-rp",
+    "name": "SOL-cbBTC Reward Pool",
+    "type": "gov",
+    "version": 2,
+    "token": "cowAerodromeSOL-cbBTC",
+    "tokenAddress": "0x8c4855c5371Cc01f6464c38515914eD42978e0f5",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "earnContractAddress": "0xAB993f20329B25c920F76EA6f898eefFF9E1A45D",
+    "earnedToken": "rCowAerodromeSOL-cbBTC",
+    "earnedTokenDecimals": 18,
+    "earnedTokenAddresses": ["0x940181a94A35A4569E4529A3CDfB74e38FD98631"],
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-sol-cbbtc",
+    "status": "active",
+    "createdAt": 1776417109,
+    "platformId": "aerodrome",
+    "assets": ["SOL", "cbBTC"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "gov-composer"
+      },
+      {
+        "strategyId": "reward-pool-to-vault"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-sol-cbbtc",
+    "name": "SOL-cbBTC",
+    "type": "cowcentrated",
+    "token": "SOL-cbBTC aerodrome",
+    "tokenAddress": "0xCcfA472815563ff9eB2de95C7b2bE1Ccf91f7F31",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "depositTokenAddresses": [
+      "0x311935Cd80B76769bF2ecC9D8Ab7635b2139cf82",
+      "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
+    ],
+    "earnContractAddress": "0x8c4855c5371Cc01f6464c38515914eD42978e0f5",
+    "earnedToken": "cowAerodromeSOL-cbBTC",
+    "earnedTokenAddress": "0x8c4855c5371Cc01f6464c38515914eD42978e0f5",
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-sol-cbbtc",
+    "status": "active",
+    "createdAt": 1776417109,
+    "platformId": "beefy",
+    "feeTier": "0.035",
+    "assets": ["SOL", "cbBTC"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "cowcentrated"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-sol-usdc-v2-vault",
+    "name": "SOL-USDC",
+    "type": "standard",
+    "token": "SOL-USDC",
+    "tokenAddress": "0x6b945aE08545193c15CC24E4523f5e0Fb3e0bEDE",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "earnContractAddress": "0xE65A1f847aE24314414153614D35831479633F73",
+    "earnedToken": "mooCowAerodromeSOL-USDCv2",
+    "earnedTokenAddress": "0xE65A1f847aE24314414153614D35831479633F73",
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-sol-usdc-v2",
+    "status": "active",
+    "createdAt": 1776416866,
+    "platformId": "aerodrome",
+    "assets": ["SOL", "USDC"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "vault-composer"
+      },
+      {
+        "strategyId": "reward-pool-to-vault"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-sol-usdc-v2-rp",
+    "name": "SOL-USDC Reward Pool",
+    "type": "gov",
+    "version": 2,
+    "token": "cowAerodromeSOL-USDCv2",
+    "tokenAddress": "0x6b945aE08545193c15CC24E4523f5e0Fb3e0bEDE",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "earnContractAddress": "0x6e49d86F1D7D11aD425eA68755014Fb9Cc1C3617",
+    "earnedToken": "rCowAerodromeSOL-USDC",
+    "earnedTokenDecimals": 18,
+    "earnedTokenAddresses": ["0x940181a94A35A4569E4529A3CDfB74e38FD98631"],
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-sol-usdc-v2",
+    "status": "active",
+    "createdAt": 1776416865,
+    "platformId": "aerodrome",
+    "assets": ["SOL", "USDC"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "gov-composer"
+      },
+      {
+        "strategyId": "reward-pool-to-vault"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-sol-usdc-v2",
+    "name": "SOL-USDC",
+    "type": "cowcentrated",
+    "token": "SOL-USDC aerodrome",
+    "tokenAddress": "0x1131DB5977242a03eBeaD1aCD18F80A9A29e5922",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "depositTokenAddresses": [
+      "0x311935Cd80B76769bF2ecC9D8Ab7635b2139cf82",
+      "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    ],
+    "earnContractAddress": "0x6b945aE08545193c15CC24E4523f5e0Fb3e0bEDE",
+    "earnedToken": "cowAerodromeSOL-USDCv2",
+    "earnedTokenAddress": "0x6b945aE08545193c15CC24E4523f5e0Fb3e0bEDE",
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-sol-usdc-v2",
+    "status": "active",
+    "createdAt": 1776416865,
+    "platformId": "beefy",
+    "feeTier": "0.035",
+    "assets": ["SOL", "USDC"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "cowcentrated"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-usdc-ghst-v2-vault",
+    "name": "GHST-USDC",
+    "type": "standard",
+    "token": "GHST-USDC",
+    "tokenAddress": "0x4cd5cAb2F70693eB656606237Ee74A55A377BEfa",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "earnContractAddress": "0xae15b86519594d91a80B7fcbB721A6EbD761C53c",
+    "earnedToken": "mooCowAerodromeUSDC-GHSTv2",
+    "earnedTokenAddress": "0xae15b86519594d91a80B7fcbB721A6EbD761C53c",
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-usdc-ghst-v2",
+    "status": "active",
+    "createdAt": 1776412627,
+    "platformId": "aerodrome",
+    "assets": ["GHST", "USDC"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "vault-composer"
+      },
+      {
+        "strategyId": "reward-pool-to-vault"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-usdc-ghst-v2-rp",
+    "name": "GHST-USDC Reward Pool",
+    "type": "gov",
+    "version": 2,
+    "token": "cowAerodromeUSDC-GHSTv2",
+    "tokenAddress": "0x4cd5cAb2F70693eB656606237Ee74A55A377BEfa",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "earnContractAddress": "0xC4Ed6d70491Ba23e2359Cc217D9ACB912d50ad6D",
+    "earnedToken": "rCowAerodromeUSDC-GHST",
+    "earnedTokenDecimals": 18,
+    "earnedTokenAddresses": ["0x940181a94A35A4569E4529A3CDfB74e38FD98631"],
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-usdc-ghst-v2",
+    "status": "active",
+    "createdAt": 1776412626,
+    "platformId": "aerodrome",
+    "assets": ["GHST", "USDC"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "gov-composer"
+      },
+      {
+        "strategyId": "reward-pool-to-vault"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-usdc-ghst-v2",
+    "name": "GHST-USDC",
+    "type": "cowcentrated",
+    "token": "GHST-USDC aerodrome",
+    "tokenAddress": "0x41D4934322f2bd6fE1dbe4124070FE61651A2067",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "depositTokenAddresses": [
+      "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "0xcD2F22236DD9Dfe2356D7C543161D4d260FD9BcB"
+    ],
+    "earnContractAddress": "0x4cd5cAb2F70693eB656606237Ee74A55A377BEfa",
+    "earnedToken": "cowAerodromeUSDC-GHSTv2",
+    "earnedTokenAddress": "0x4cd5cAb2F70693eB656606237Ee74A55A377BEfa",
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-usdc-ghst-v2",
+    "status": "active",
+    "createdAt": 1776412626,
+    "platformId": "beefy",
+    "feeTier": "1",
+    "assets": ["GHST", "USDC"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "cowcentrated"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-weth-drv-vault",
+    "name": "DRV-WETH",
+    "type": "standard",
+    "token": "DRV-WETH",
+    "tokenAddress": "0x353c486F578047a34304a861cEed711356130Ade",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "earnContractAddress": "0x803697f2CB0E9e7C8c8f7090Ed8dBBe744C754c6",
+    "earnedToken": "mooCowAerodromeWETH-DRVv2",
+    "earnedTokenAddress": "0x803697f2CB0E9e7C8c8f7090Ed8dBBe744C754c6",
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-weth-drv",
+    "status": "active",
+    "createdAt": 1776412081,
+    "platformId": "aerodrome",
+    "assets": ["DRV", "WETH"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "vault-composer"
+      },
+      {
+        "strategyId": "reward-pool-to-vault"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-weth-drv-rp",
+    "name": "DRV-WETH Reward Pool",
+    "type": "gov",
+    "version": 2,
+    "token": "cowAerodromeWETH-DRVv2",
+    "tokenAddress": "0x353c486F578047a34304a861cEed711356130Ade",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "earnContractAddress": "0x7C62697504E622A9FC5C06D64a3Dccb46288D5fF",
+    "earnedToken": "rCowAerodromeWETH-DRV",
+    "earnedTokenDecimals": 18,
+    "earnedTokenAddresses": ["0x940181a94A35A4569E4529A3CDfB74e38FD98631"],
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-weth-drv",
+    "status": "active",
+    "createdAt": 1776412080,
+    "platformId": "aerodrome",
+    "assets": ["DRV", "WETH"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "gov-composer"
+      },
+      {
+        "strategyId": "reward-pool-to-vault"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-weth-drv",
+    "name": "DRV-WETH",
+    "type": "cowcentrated",
+    "token": "DRV-WETH aerodrome",
+    "tokenAddress": "0xEF7E596AEF9e4c6301b4D1F1e88F8fFE8C306222",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "depositTokenAddresses": [
+      "0x4200000000000000000000000000000000000006",
+      "0x9d0E8f5b25384C7310CB8C6aE32C8fbeb645d083"
+    ],
+    "earnContractAddress": "0x353c486F578047a34304a861cEed711356130Ade",
+    "earnedToken": "cowAerodromeWETH-DRVv2",
+    "earnedTokenAddress": "0x353c486F578047a34304a861cEed711356130Ade",
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-weth-drv",
+    "status": "active",
+    "createdAt": 1776412080,
+    "platformId": "beefy",
+    "feeTier": "0.8",
+    "assets": ["DRV", "WETH"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "cowcentrated"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-weth-vvv-v2-vault",
+    "name": "VVV-WETH",
+    "type": "standard",
+    "token": "VVV-WETH",
+    "tokenAddress": "0xB3D0A7EEc306586920c5aC81F53c7B33b91cF678",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "earnContractAddress": "0x34e36c466CA95b9299d1c386E9745D43e0fb033f",
+    "earnedToken": "mooCowAerodromeWETH-VVV",
+    "earnedTokenAddress": "0x34e36c466CA95b9299d1c386E9745D43e0fb033f",
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-weth-vvv-v2",
+    "status": "active",
+    "createdAt": 1776379868,
+    "platformId": "aerodrome",
+    "assets": ["VVV", "WETH"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "vault-composer"
+      },
+      {
+        "strategyId": "reward-pool-to-vault"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-weth-vvv-v2-rp",
+    "name": "VVV-WETH Reward Pool",
+    "type": "gov",
+    "version": 2,
+    "token": "cowAerodromeWETH-VVVv2",
+    "tokenAddress": "0xB3D0A7EEc306586920c5aC81F53c7B33b91cF678",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "earnContractAddress": "0xe5f82F6A8769C1C3927CED61782798268A9c69eE",
+    "earnedToken": "rCowAerodromeWETH-VVV",
+    "earnedTokenDecimals": 18,
+    "earnedTokenAddresses": ["0x940181a94A35A4569E4529A3CDfB74e38FD98631"],
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-weth-vvv-v2",
+    "status": "active",
+    "createdAt": 1776379868,
+    "platformId": "aerodrome",
+    "assets": ["VVV", "WETH"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "gov-composer"
+      },
+      {
+        "strategyId": "reward-pool-to-vault"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-weth-vvv-v2",
+    "name": "VVV-WETH",
+    "type": "cowcentrated",
+    "token": "VVV-WETH aerodrome",
+    "tokenAddress": "0xA135B59Fe221C0c8D441294f97f96Fbc37Bc9fbE",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "depositTokenAddresses": [
+      "0x4200000000000000000000000000000000000006",
+      "0xacfE6019Ed1A7Dc6f7B508C02d1b04ec88cC21bf"
+    ],
+    "earnContractAddress": "0xB3D0A7EEc306586920c5aC81F53c7B33b91cF678",
+    "earnedToken": "cowAerodromeWETH-VVVv2",
+    "earnedTokenAddress": "0xB3D0A7EEc306586920c5aC81F53c7B33b91cF678",
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-weth-vvv-v2",
+    "status": "active",
+    "createdAt": 1776379867,
+    "platformId": "beefy",
+    "feeTier": "0.3",
+    "assets": ["VVV", "WETH"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "cowcentrated"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-weth-zro-vault",
+    "name": "ZRO-WETH",
+    "type": "standard",
+    "token": "ZRO-WETH",
+    "tokenAddress": "0x0abD63A4116e1bF4Ff25aE181201eE59B760B644",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "earnContractAddress": "0x8F77BD620D99a56De979121FbdFC106EE8C48927",
+    "earnedToken": "mooCowAerodromeZRO-WETH",
+    "earnedTokenAddress": "0x8F77BD620D99a56De979121FbdFC106EE8C48927",
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-weth-zro",
+    "status": "active",
+    "createdAt": 1776378071,
+    "platformId": "aerodrome",
+    "assets": ["ZRO", "WETH"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": true,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "vault-composer"
+      },
+      {
+        "strategyId": "reward-pool-to-vault"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-weth-zro-rp",
+    "name": "ZRO-WETH Reward Pool",
+    "type": "gov",
+    "version": 2,
+    "token": "cowAerodromeZRO-WETH",
+    "tokenAddress": "0x0abD63A4116e1bF4Ff25aE181201eE59B760B644",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "earnContractAddress": "0xB262A553B66962aA2c6cB0139bc11562D2CdCe32",
+    "earnedToken": "rCowAerodromeZRO-WETH",
+    "earnedTokenDecimals": 18,
+    "earnedTokenAddresses": ["0x940181a94A35A4569E4529A3CDfB74e38FD98631"],
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-weth-zro",
+    "status": "active",
+    "createdAt": 1776378070,
+    "platformId": "aerodrome",
+    "assets": ["ZRO", "WETH"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": true,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "gov-composer"
+      },
+      {
+        "strategyId": "reward-pool-to-vault"
+      }
+    ]
+  },
+  {
+    "id": "aerodrome-cow-base-weth-zro",
+    "name": "ZRO-WETH",
+    "type": "cowcentrated",
+    "token": "WETH-ZRO aerodrome",
+    "tokenAddress": "0x717e174d5dAe280802D1a2c15C1C0976561A3f61",
+    "tokenDecimals": 18,
+    "tokenProviderId": "aerodrome",
+    "depositTokenAddresses": [
+      "0x4200000000000000000000000000000000000006",
+      "0x6985884C4392D348587B19cb9eAAf157F13271cd"
+    ],
+    "earnContractAddress": "0x0abD63A4116e1bF4Ff25aE181201eE59B760B644",
+    "earnedToken": "cowAerodromeWETH-ZRO",
+    "earnedTokenAddress": "0x0abD63A4116e1bF4Ff25aE181201eE59B760B644",
+    "oracle": "lps",
+    "oracleId": "aerodrome-cow-base-weth-zro",
+    "status": "active",
+    "createdAt": 1776378070,
+    "platformId": "beefy",
+    "feeTier": "0.15",
+    "assets": ["ZRO", "WETH"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": true,
+      "notTimelocked": true,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "pool",
+    "network": "base",
+    "zaps": [
+      {
+        "strategyId": "cowcentrated"
+      }
+    ]
+  },
+  {
     "id": "aerodrome-cow-base-rave-usdc-vault",
     "name": "RAVE-USDC",
     "type": "standard",
@@ -26795,7 +27739,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -26840,7 +27784,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -26886,7 +27830,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -28813,7 +29757,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -28856,7 +29800,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -32397,7 +33341,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -32434,7 +33378,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -32471,7 +33415,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -32902,7 +33846,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -32943,7 +33887,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -32984,7 +33928,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },

--- a/src/config/vault/bsc.json
+++ b/src/config/vault/bsc.json
@@ -4862,7 +4862,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -4903,7 +4903,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -4947,7 +4947,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },

--- a/src/config/vault/optimism.json
+++ b/src/config/vault/optimism.json
@@ -3958,7 +3958,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -3995,7 +3995,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -4777,7 +4777,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },
@@ -4818,7 +4818,7 @@
       "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
-      "notTimelocked": false,
+      "notTimelocked": true,
       "notVerified": false,
       "synthAsset": false
     },


### PR DESCRIPTION
Migration of first 7 deprecated Aero gauges to Fron's new strategy (V4). Add new gauge for SOL-cbBTC.

Agreed with Weso to add no timelock warning to ZRO. setPeers() functionality is owned by a multisig without timelock.

Please merge together with EOL of deprecated Aero gauges [here](https://github.com/beefyfinance/beefy-v2/pull/3059).

See associated [API PR](https://github.com/beefyfinance/beefy-api/pull/1764).