### PR TITLE
fix(points-banner): grid lines missing in production

### DIFF
--- a/src/features/vault/components/PointsBanner/PointsBanner.tsx
+++ b/src/features/vault/components/PointsBanner/PointsBanner.tsx
@@ -75,7 +75,7 @@ const Header = styled('div', {
     padding: '16px',
     backgroundColor: 'background.content.points',
     backgroundImage:
-      'linear-gradient(to right, var(--colors-white-70-24a) 1px, transparent 1px), linear-gradient(to bottom, var(--colors-white-70-24a) 1px, transparent 1px)',
+      'linear-gradient(to right, {colors.white.70-24a} 1px, transparent 1px), linear-gradient(to bottom, {colors.white.70-24a} 1px, transparent 1px)',
     backgroundSize: '51px 100%, 100% 39px',
     backgroundPosition: '25px 0, 0 20px',
     backgroundRepeat: 'repeat-x, repeat-y',


### PR DESCRIPTION
## Summary
- The points banner header grid background was using a hardcoded `var(--colors-white-70-24a)` reference, which breaks in production because Panda hashes CSS variable names (`hash: { cssVar: true }` in `panda.config.ts`). The literal name resolves to nothing in built CSS, so both `linear-gradient` calls render empty and the grid disappears. Visible only in local dev where hashing is off.
- Swapped to Panda's `{colors.white.70-24a}` token-reference syntax inside the `backgroundImage` string — the same pattern used in `VirtualVaultsList.tsx`. Panda substitutes the hashed var at build time, so the grid survives production builds.

Follow-up to #3099.

## Test plan
- [ ] Visit an eligible vault page (e.g. `/vault/kumbaya-cow-megaeth-weth-usdm-rp`) on the deploy preview.
- [ ] Header of the points banner shows the faint grey grid lines (white at ~24% alpha) over the dark surface.
- [ ] `tsc` / `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)