### PR TITLE
Add Arbitrum Uniswap V3 WBTC-cbBTC CLM

### DIFF
--- a/src/config/vault/arbitrum.json
+++ b/src/config/vault/arbitrum.json
@@ -135,6 +135,7 @@
     "createdAt": 1778774244,
     "platformId": "beefy",
     "feeTier": "0.01",
+    "tickSpacing": 1,
     "assets": ["WBTC", "cbBTC"],
     "risks": {
       "complex": true,

--- a/src/config/vault/arbitrum.json
+++ b/src/config/vault/arbitrum.json
@@ -37,6 +37,43 @@
     ]
   },
   {
+    "id": "uniswap-cow-arbitrum-wbtc-cbbtc-rp",
+    "name": "WBTC-cbBTC Reward Pool",
+    "type": "gov",
+    "version": 2,
+    "token": "cowUniswapArbitrumWBTC-cbBTC",
+    "tokenAddress": "0x618D9328EB1D06dFfD2CB4B67523b2cB5740e32f",
+    "tokenDecimals": 18,
+    "tokenProviderId": "uniswap",
+    "earnContractAddress": "0x6B29227D91F1317bb945FbCC87B37ef39d04C5f8",
+    "earnedToken": "rCowUniswapArbitrumWBTC-cbBTC",
+    "earnedTokenDecimals": 18,
+    "earnedTokenAddresses": [],
+    "oracle": "lps",
+    "oracleId": "uniswap-cow-arbitrum-wbtc-cbbtc",
+    "status": "active",
+    "createdAt": 1778774244,
+    "platformId": "uniswap",
+    "assets": ["WBTC", "cbBTC"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": false,
+      "notTimelocked": false,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "compounds",
+    "network": "arbitrum",
+    "zaps": [
+      {
+        "strategyId": "gov-composer"
+      }
+    ]
+  },
+  {
     "id": "uniswap-cow-arbitrum-mor-weth",
     "name": "MOR-WETH",
     "type": "cowcentrated",
@@ -66,6 +103,46 @@
       "notBattleTested": false,
       "notCorrelated": true,
       "notTimelocked": true,
+      "notVerified": false,
+      "synthAsset": false
+    },
+    "strategyTypeId": "compounds",
+    "network": "arbitrum",
+    "zaps": [
+      {
+        "strategyId": "cowcentrated"
+      }
+    ]
+  },
+  {
+    "id": "uniswap-cow-arbitrum-wbtc-cbbtc",
+    "name": "WBTC-cbBTC",
+    "type": "cowcentrated",
+    "token": "WBTC-cbBTC uniswap",
+    "tokenAddress": "0x9B42809aaaE8d088eE01FE637E948784730F0386",
+    "tokenDecimals": 18,
+    "tokenProviderId": "uniswap",
+    "depositTokenAddresses": [
+      "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
+      "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
+    ],
+    "earnContractAddress": "0x618D9328EB1D06dFfD2CB4B67523b2cB5740e32f",
+    "earnedToken": "cowUniswapArbitrumWBTC-cbBTC",
+    "earnedTokenAddress": "0x618D9328EB1D06dFfD2CB4B67523b2cB5740e32f",
+    "oracle": "lps",
+    "oracleId": "uniswap-cow-arbitrum-wbtc-cbbtc",
+    "status": "active",
+    "createdAt": 1778774244,
+    "platformId": "beefy",
+    "feeTier": "0.01",
+    "assets": ["WBTC", "cbBTC"],
+    "risks": {
+      "complex": true,
+      "curated": false,
+      "notAudited": false,
+      "notBattleTested": false,
+      "notCorrelated": false,
+      "notTimelocked": false,
       "notVerified": false,
       "synthAsset": false
     },


### PR DESCRIPTION
Adds two entries to `src/config/vault/arbitrum.json` for the new CLM vault: the cowcentrated vault itself (`uniswap-cow-arbitrum-wbtc-cbbtc`) and its gov reward pool (`uniswap-cow-arbitrum-wbtc-cbbtc-rp`).

Pool: WBTC/cbBTC Uniswap V3 0.01% on Arbitrum — `0x9B42809aaaE8d088eE01FE637E948784730F0386`. BTC-BTC like-asset, ~zero IL profile.

| Contract | Address |
|---|---|
| CLM vault (cowcentrated entry) | [`0x618D9328EB1D06dFfD2CB4B67523b2cB5740e32f`](https://arbiscan.io/address/0x618D9328EB1D06dFfD2CB4B67523b2cB5740e32f) |
| Reward pool (gov entry) | [`0x6B29227D91F1317bb945FbCC87B37ef39d04C5f8`](https://arbiscan.io/address/0x6B29227D91F1317bb945FbCC87B37ef39d04C5f8) |

Strategy params: `positionWidth=20` (≈ ±0.2% main position), `maxTickDeviation=2`, `twapInterval=120`. Mirrors the existing `uniswap-cow-arb-wbtc-tbtc` BTC/BTC vault's tick-band profile. `risks.notCorrelated=false` and `notTimelocked=false` (strategy owner is `0x6d28afD…D89F`, the production Beefy strategyOwner timelock).

**Mainnet lifecycle verified**: deposit → panic → withdrawAll → unpause → redeposit, all executed by the deployer pre-ownership-transfer. Full tx list in the API PR description.

**Dependencies before merge**:
1. **API PR** beefyfinance/beefy-api#1797 merged + `@beefyfinance/blockchain-addressbook` bumped (adds cbBTC to Arbitrum tokens — currently triggers `validate` warning *"Asset cbBTC not in addressbook on arbitrum"*).
2. **Keeper executes pre-activation wiring** on Arbitrum (setOracle + setSwapInfo calldata in API PR body) — currently triggers `validate` error *"Beefy oracle has no subOracle entry for token1 0xcbB7C…33Bf"*.

Once both land the `Validate PR` action will pass green. Local `npm run prettier --check src/config/vault/arbitrum.json` clean.