### PR TITLE
refactor(date): unify date formatting under shared helpers

### DIFF
--- a/src/components/AppVersionCheck/AppVersionCheck.tsx
+++ b/src/components/AppVersionCheck/AppVersionCheck.tsx
@@ -30,12 +30,7 @@ export const AppVersionCheck = memo(function AppVersionCheck() {
   const message = useMemo(() => {
     if (app.updateAvailable) {
       const key = app.reloadFailed ? 'Update-Available-Failed' : 'Update-Available';
-      return t(key, {
-        currentDate: new Date(app.currentVersion.timestamp).toLocaleString(),
-        currentVersion: app.currentVersion.git || app.currentVersion.content,
-        newDate: new Date(app.newVersion.timestamp).toLocaleString(),
-        newVersion: app.newVersion.git || app.newVersion.content,
-      });
+      return t(key);
     }
     return undefined;
   }, [t, app]);

--- a/src/components/PriceWithChange/PriceWithChange.tsx
+++ b/src/components/PriceWithChange/PriceWithChange.tsx
@@ -1,11 +1,11 @@
 import { css, type CssStyles } from '@repo/styles/css';
 import type BigNumber from 'bignumber.js';
-import { format } from 'date-fns';
 import { memo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { fetchHistoricalPrices } from '../../features/data/actions/historical.ts';
 import { selectPriceWithChange } from '../../features/data/selectors/tokens.ts';
 import { BIG_ZERO } from '../../helpers/big-number.ts';
+import { formatDateTime } from '../../helpers/date.ts';
 import { formatLargePercent, formatLargeUsd, formatUsd } from '../../helpers/format.ts';
 import { useAppDispatch, useAppSelector } from '../../features/data/store/hooks.ts';
 import { DivWithTooltip } from '../Tooltip/DivWithTooltip.tsx';
@@ -89,7 +89,7 @@ const WithChange = memo(function WithChange({
     }`,
     {
       change: formatUsd(diffAbs, diffAbs.gte(0.01) ? 2 : 4),
-      date: format(previousDate, 'MMM d, yyyy h:mm a'),
+      date: formatDateTime(previousDate),
     }
   );
 

--- a/src/features/dashboard/components/UserVaults/components/VaultTransactions/components/Transaction/Transaction.tsx
+++ b/src/features/dashboard/components/UserVaults/components/VaultTransactions/components/Transaction/Transaction.tsx
@@ -1,12 +1,16 @@
 import { css } from '@repo/styles/css';
 import type BigNumber from 'bignumber.js';
-import { formatISO9075 } from 'date-fns';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TokenAmount } from '../../../../../../../../components/TokenAmount/TokenAmount.tsx';
 import { TokenImage } from '../../../../../../../../components/TokenImage/TokenImage.tsx';
 import { VaultNetwork } from '../../../../../../../../components/VaultIdentity/VaultIdentity.tsx';
 import { BIG_ZERO } from '../../../../../../../../helpers/big-number.ts';
+import {
+  formatDate,
+  formatDateTimeWithSeconds,
+  formatTimeWithSeconds,
+} from '../../../../../../../../helpers/date.ts';
 import {
   formatLargeUsd,
   formatTokenDisplayCondensed,
@@ -40,10 +44,7 @@ type TransactionProps = {
 };
 
 type TransactionStatProps<
-  T extends
-    | TimelineEntryStandard
-    | TimelineEntryCowcentratedPool
-    | TimelineEntryCowcentratedVault =
+  T extends TimelineEntryStandard | TimelineEntryCowcentratedPool | TimelineEntryCowcentratedVault =
     | TimelineEntryStandard
     | TimelineEntryCowcentratedPool
     | TimelineEntryCowcentratedVault,
@@ -184,9 +185,9 @@ export const Transaction = memo(function Transaction({ tx }: TransactionProps) {
         />
         {transactionHash ?
           <ExternalLink href={explorerTxUrl(chain, transactionHash)} className={classes.link}>
-            {formatISO9075(datetime)}
+            {formatDateTimeWithSeconds(datetime)}
           </ExternalLink>
-        : formatISO9075(datetime)}
+        : formatDateTimeWithSeconds(datetime)}
       </div>
       <InfoGrid>
         {/*Amount */}
@@ -237,12 +238,12 @@ export const TransactionMobile = memo(function TransactionMobile({ tx }: Transac
         <div className={classes.statMobile}>
           {transactionHash ?
             <ExternalLink href={explorerTxUrl(chain, transactionHash)} className={classes.link}>
-              {formatISO9075(datetime, { representation: 'date' })}
+              {formatDate(datetime)}
             </ExternalLink>
-          : formatISO9075(datetime, { representation: 'date' })}
+          : formatDate(datetime)}
         </div>
         <div className={css(styles.statMobile, styles.textDark)}>
-          {formatISO9075(datetime, { representation: 'time' })}
+          {formatTimeWithSeconds(datetime)}
         </div>
       </InfoGrid>
       <InfoGrid>

--- a/src/features/vault/components/Actions/Transact/WithdrawQueue/Countdown.tsx
+++ b/src/features/vault/components/Actions/Transact/WithdrawQueue/Countdown.tsx
@@ -1,9 +1,8 @@
 import { memo, type ReactNode, useMemo } from 'react';
-import { format } from 'date-fns';
 import { DivWithTooltip } from '../../../../../../components/Tooltip/DivWithTooltip.tsx';
 import { BasicTooltipContent } from '../../../../../../components/Tooltip/BasicTooltipContent.tsx';
 import { TimeUntil } from '../../../../../../components/TimeUntil/TimeUntil.tsx';
-import type { FormatTimeLabels } from '../../../../../../helpers/date.ts';
+import { formatDateTime, type FormatTimeLabels } from '../../../../../../helpers/date.ts';
 import { StatusPill } from '../../../../../../components/StatusPill.tsx';
 
 type CountdownProps = {
@@ -21,7 +20,7 @@ const labels: FormatTimeLabels = {
 export const Countdown = memo(function Countdown({ until, children }: CountdownProps) {
   const { time, renderFuture } = useMemo(() => {
     const date = new Date(until * 1000);
-    const formatted = format(date, 'MMM d, yyyy h:mm a');
+    const formatted = formatDateTime(date);
     return {
       time: date,
       renderFuture: (timeLeft: string) => (

--- a/src/features/vault/components/HistoricGraph/Graph/Graph.tsx
+++ b/src/features/vault/components/HistoricGraph/Graph/Graph.tsx
@@ -1,5 +1,5 @@
 import { token } from '@repo/styles/tokens';
-import { format, fromUnixTime } from 'date-fns';
+import { fromUnixTime } from 'date-fns';
 import { max as lodashMax } from 'lodash-es';
 import { memo, useCallback, useMemo } from 'react';
 import {
@@ -15,6 +15,7 @@ import {
 } from 'recharts';
 import { useBreakpoint } from '../../../../../hooks/useBreakpoint.ts';
 import { XAxisTick } from '../../../../../components/XAxisTick/XAxisTick.tsx';
+import { formatChartDate, formatTime } from '../../../../../helpers/date.ts';
 import {
   formatLargePercent,
   formatTokenDisplayCondensed,
@@ -190,7 +191,7 @@ export const Graph = memo(function Graph<TStat extends ChartStat>({
 const formatDateTimeTick = (timestamp: number, bucket: ApiTimeBucket) => {
   const date = fromUnixTime(timestamp);
   if (bucket === '1h_1d') {
-    return format(date, 'HH:mm');
+    return formatTime(date);
   }
-  return date.toLocaleDateString(undefined, { month: 'numeric', day: 'numeric' });
+  return formatChartDate(date);
 };

--- a/src/features/vault/components/HistoricGraph/TooltipContent/TooltipContent.tsx
+++ b/src/features/vault/components/HistoricGraph/TooltipContent/TooltipContent.tsx
@@ -2,8 +2,9 @@ import { memo, useMemo } from 'react';
 import { legacyMakeStyles } from '../../../../../helpers/mui.ts';
 import type { ApiTimeBucket } from '../../../../data/apis/beefy/beefy-data-api-types.ts';
 import type { LineTogglesState } from '../LineToggles/LineToggles.tsx';
-import { format, fromUnixTime } from 'date-fns';
+import { fromUnixTime } from 'date-fns';
 import { useTranslation } from 'react-i18next';
+import { formatDateTime } from '../../../../../helpers/date.ts';
 import { getBucketParams } from '../utils.ts';
 import { styles } from './styles.ts';
 import { css } from '@repo/styles/css';
@@ -62,9 +63,7 @@ export const TooltipContent = memo(function TooltipContent<TStat extends ChartSt
 
   return (
     <div className={classes.content}>
-      <div className={classes.timestamp}>
-        {format(fromUnixTime(timestamp), 'MMM d, yyyy h:mm a')}
-      </div>
+      <div className={classes.timestamp}>{formatDateTime(fromUnixTime(timestamp))}</div>
       <div className={classes.itemContainer}>
         <div className={classes.label}>{t([`Graph-${vaultType}-${stat}`, `Graph-${stat}`])}:</div>
         <div className={classes.value}>

--- a/src/features/vault/components/PnLGraph/cowcentrated/components/Tooltips/Tooltips.tsx
+++ b/src/features/vault/components/PnLGraph/cowcentrated/components/Tooltips/Tooltips.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { format } from 'date-fns';
+import { formatDateTime } from '../../../../../../../helpers/date.ts';
 import { formatTokenDisplayCondensed, formatUsd } from '../../../../../../../helpers/format.ts';
 import { legacyMakeStyles } from '../../../../../../../helpers/mui.ts';
 import { featureFlag_detailedTooltips } from '../../../../../../data/utils/feature-flags.ts';
@@ -69,7 +69,7 @@ export const OverviewTooltip = memo(function OverviewTooltip({
 
   return (
     <div className={classes.content}>
-      <div>{format(timestamp, 'MMM d, yyyy h:mm a')}</div>
+      <div>{formatDateTime(timestamp)}</div>
       <div className={classes.itemContainer}>
         <div className={classes.label}>{t('Graph-cowcentrated-overview-tooltip-position')}:</div>
         <div className={classes.value}>{formatTokenDisplayCondensed(underlying, 18)}</div>
@@ -124,7 +124,7 @@ export const FeesTooltip = memo(function FeesTooltip({
 
   return (
     <div className={classes.content}>
-      <div>{format(timestamp, 'MMM d, yyyy h:mm a')}</div>
+      <div>{formatDateTime(timestamp * 1000)}</div>
       {tokens.map((token, i) => (
         <div className={classes.itemContainer} key={token.id}>
           <div className={classes.label}>{token.symbol}:</div>

--- a/src/features/vault/components/PnLGraph/standard/components/PnLTooltip/PnLTooltip.tsx
+++ b/src/features/vault/components/PnLGraph/standard/components/PnLTooltip/PnLTooltip.tsx
@@ -1,8 +1,8 @@
 import { legacyMakeStyles } from '../../../../../../../helpers/mui.ts';
 import BigNumber from 'bignumber.js';
-import { format } from 'date-fns';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { formatDateTime } from '../../../../../../../helpers/date.ts';
 import {
   formatLargeUsd,
   formatTokenDisplayCondensed,
@@ -50,7 +50,7 @@ export const PnLTooltip = memo(function PnLTooltip({ active, payload }: TooltipP
   const classes = useStyles();
   const { t } = useTranslation();
   if (active && payload && payload.length) {
-    const formattedDate = format(new Date(payload[0].payload.datetime), 'MMM d, yyyy h:mm a');
+    const formattedDate = formatDateTime(new Date(payload[0].payload.datetime));
     const shares = new BigNumber(payload[0].payload.underlyingBalance);
     const usdBalance = new BigNumber(payload[0].payload.usdBalance);
 

--- a/src/helpers/date.ts
+++ b/src/helpers/date.ts
@@ -204,3 +204,79 @@ export function isLessThanDurationAgoUnix(unixDate: number, duration: Duration):
 export function getUnixNow(): number {
   return Math.trunc(Date.now() / 1000);
 }
+
+// App is English-only (see i18n.ts), but we want US/EU date-order conventions
+// to follow the user's region. Pin to `en-<REGION>` so months stay in English
+// while ordering (MM/DD vs DD/MM) follows the browser's regional setting.
+const resolvedLocale = (() => {
+  const region = new Intl.Locale(navigator.language).region;
+  return region ? `en-${region}` : 'en-US';
+})();
+
+const dateTimeFormatter = new Intl.DateTimeFormat(resolvedLocale, {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+});
+
+const dateTimeWithSecondsFormatter = new Intl.DateTimeFormat(resolvedLocale, {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+});
+
+const dateFormatter = new Intl.DateTimeFormat(resolvedLocale, {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+});
+
+const timeFormatter = new Intl.DateTimeFormat(resolvedLocale, {
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+});
+
+const timeWithSecondsFormatter = new Intl.DateTimeFormat(resolvedLocale, {
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+});
+
+// Numeric for chart axes where tick width is constrained
+const chartDateFormatter = new Intl.DateTimeFormat(resolvedLocale, {
+  month: 'numeric',
+  day: 'numeric',
+});
+
+export function formatDateTime(date: Date | number): string {
+  return dateTimeFormatter.format(date);
+}
+
+export function formatDateTimeWithSeconds(date: Date | number): string {
+  return dateTimeWithSecondsFormatter.format(date);
+}
+
+export function formatDate(date: Date | number): string {
+  return dateFormatter.format(date);
+}
+
+export function formatTime(date: Date | number): string {
+  return timeFormatter.format(date);
+}
+
+export function formatTimeWithSeconds(date: Date | number): string {
+  return timeWithSecondsFormatter.format(date);
+}
+
+export function formatChartDate(date: Date | number): string {
+  return chartDateFormatter.format(date);
+}

--- a/src/helpers/graph/graph.ts
+++ b/src/helpers/graph/graph.ts
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { formatChartDate, formatTime } from '../date.ts';
 import { formatLargeUsd } from '../format.ts';
 import type { GraphBucket, GraphBucketParamMap } from './types.ts';
 
@@ -46,10 +46,9 @@ export function makeUnderlyingTickFormatter(domain: [number, number]) {
 
 export function makeDateTimeTickFormatter(timeBucket: GraphBucket) {
   if (timeBucket === '1h_1d') {
-    return (value: number) => format(value, 'HH:mm');
+    return (value: number) => formatTime(value);
   }
-  return (value: number) =>
-    new Date(value).toLocaleDateString(undefined, { month: 'numeric', day: 'numeric' });
+  return (value: number) => formatChartDate(value);
 }
 
 const bucketParamMap = {


### PR DESCRIPTION
## Summary
- Six `Intl.DateTimeFormat`-based helpers in `src/helpers/date.ts`; 12 UI call sites migrated. 24h, English month names, region-aware ordering (`en-<REGION>` from `navigator.language`).
- Fixes a unix-seconds-as-ms bug in the cowcentrated FeesTooltip (was rendering 1970 dates).
- Removes dead date interpolation in `AppVersionCheck` (no locale string referenced the keys).

## Test plan
- [ ] HistoricGraph tooltip + x-axis across all time buckets
- [ ] WithdrawQueue countdown tooltip
- [ ] PnL tooltips (standard + cowcentrated overview + cowcentrated fees)
- [ ] PriceWithChange tooltip
- [ ] Transaction history desktop + mobile
- [ ] App update banner via `featureFlag_simUpdate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)