### PR TITLE
fix(stepper): format boost success amount to avoid scientific notation

### DIFF
--- a/src/components/Stepper/components/Content/Success/BoostStakeSuccessContent.tsx
+++ b/src/components/Stepper/components/Content/Success/BoostStakeSuccessContent.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { selectBoostAdditionalData } from '../../../../../features/data/selectors/stepper.ts';
 import { useAppSelector } from '../../../../../features/data/store/hooks.ts';
 import { BIG_ZERO } from '../../../../../helpers/big-number.ts';
+import { formatTokenDisplayCondensed } from '../../../../../helpers/format.ts';
 import { SuccessContentDisplay } from './SuccessContentDisplay.tsx';
 import type { SuccessContentProps } from './types.ts';
 
@@ -12,7 +13,7 @@ export const BoostStakeSuccessContent = memo(function BoostStakeSuccessContent({
   const { t } = useTranslation();
   const data = useAppSelector(selectBoostAdditionalData);
   const token = data?.token.symbol || 'UNKNOWN';
-  const amount = data?.amount || BIG_ZERO;
+  const amount = formatTokenDisplayCondensed(data?.amount || BIG_ZERO, data?.token.decimals || 18);
 
   return (
     <SuccessContentDisplay

--- a/src/components/Stepper/components/Content/Success/BoostUnstakeSuccessContent.tsx
+++ b/src/components/Stepper/components/Content/Success/BoostUnstakeSuccessContent.tsx
@@ -6,6 +6,7 @@ import {
 } from '../../../../../features/data/selectors/stepper.ts';
 import { useAppSelector } from '../../../../../features/data/store/hooks.ts';
 import { BIG_ZERO } from '../../../../../helpers/big-number.ts';
+import { formatTokenDisplayCondensed } from '../../../../../helpers/format.ts';
 import { formatTokenAmountsList } from '../common/formatTokenAmountsList.tsx';
 import { SuccessContentDisplay } from './SuccessContentDisplay.tsx';
 import type { SuccessContentProps } from './types.ts';
@@ -16,7 +17,7 @@ export const BoostUnstakeSuccessContent = memo(function BoostUnstakeSuccessConte
   const { t } = useTranslation();
   const data = useAppSelector(selectBoostAdditionalData);
   const token = data?.token.symbol || 'UNKNOWN';
-  const amount = data?.amount || BIG_ZERO;
+  const amount = formatTokenDisplayCondensed(data?.amount || BIG_ZERO, data?.token.decimals || 18);
   const claimedTokenAmounts = useAppSelector(selectBoostClaimed);
   const claimed = useMemo(() => {
     if (claimedTokenAmounts.length) {


### PR DESCRIPTION
## Summary
- Boost stake/unstake success messages were interpolating a raw `BigNumber` into the i18n string, so tiny values rendered in scientific notation (e.g. `1.4227083365e-8`).
- Run the amount through `formatTokenDisplayCondensed(amount, decimals)` before interpolation — same pattern already used in `FallbackSuccessContent` and `ZapSuccessContent`.

## Test plan
- [ ] Stake a tiny amount into a Boost (anything that previously rendered as `Xe-N`) and confirm the success modal shows a readable decimal.
- [ ] Unstake from a Boost and confirm the same.
- [ ] Normal-sized stake/unstake amounts still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)