### PR TITLE
fix(dashboard): keep active tab frame from peeking above sticky filter

### DIFF
--- a/src/features/dashboard/components/UserVaults/components/Filter/styles.ts
+++ b/src/features/dashboard/components/UserVaults/components/Filter/styles.ts
@@ -15,7 +15,7 @@ export const styles = {
     lg: {
       position: 'sticky',
       top: 0,
-      zIndex: '[1]',
+      zIndex: '[2]',
     },
   }),
   sortColumns: css.raw({


### PR DESCRIPTION
## Summary
- The active `ToggleButton`'s `::before` pseudo-element draws a 3px colored frame extending 2px around the button at `z-index: 1`. Since `position: relative` on the button doesn't create a stacking context (no `z-index` on the button itself), the pseudo-element's `z-index: 1` lands in the root stacking context — same level as the sticky dashboard filter bar.
- With equal z-indices, DOM order decides painting order. The tab container comes after the sticky filter, so the active tab's frame was painted over the sticky bar's bottom edge when scrolling.
- Bumped the sticky filter's `z-index` from `1` to `2` so it sits cleanly above the tab frame.

## Test plan
- [ ] Open the dashboard, expand a user vault row, scroll so the row's tab buttons (Transaction History / Position Chart / Compounds Chart) scroll up under the sticky filter bar.
- [ ] Confirm the active tab's colored frame no longer peeks above the sticky bar.
- [ ] Verify the sticky filter dropdowns (AT DEPOSIT, NOW, YIELD, PNL, APY, DAILY YIELD) still open correctly and aren't visually clipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)