### PR TITLE
chore(points): remove MegaETH Terminal campaign (ended)

### DIFF
--- a/src/config/points.json
+++ b/src/config/points.json
@@ -671,26 +671,5 @@
         "url": "https://app.re.xyz/points"
       }
     ]
-  },
-  {
-    "id": "megaeth-terminal",
-    "docs": "https://megaeth.com",
-    "points": [
-      {
-        "id": "megaeth-terminal",
-        "name": "MegaETH Points"
-      }
-    ],
-    "eligibility": [
-      {
-        "type": "vault-whitelist"
-      }
-    ],
-    "banner": {
-      "by": "MegaETH Terminal",
-      "description": "Earn points on MegaETH Terminal for interacting with ecosystem-aligned apps and assets. Terminal is the surface area for gamified ecosystem discovery on MegaETH where user activities are tracked and rewarded. Eligible Beefy vaults are included within the Terminal points program, subject to hidden usage criteria.",
-      "learn": "https://megaeth.com",
-      "chainIcon": "megaeth"
-    }
   }
 ]

--- a/src/config/vault/megaeth.json
+++ b/src/config/vault/megaeth.json
@@ -96,7 +96,6 @@
     "createdAt": 1777543532,
     "platformId": "kumbaya",
     "assets": ["MEGA", "USDm"],
-    "pointStructureIds": ["megaeth-terminal"],
     "risks": {
       "complex": true,
       "curated": false,
@@ -175,7 +174,6 @@
     "createdAt": 1777555418,
     "platformId": "prism",
     "assets": ["MEGA", "USDm"],
-    "pointStructureIds": ["megaeth-terminal"],
     "risks": {
       "complex": true,
       "curated": false,
@@ -757,7 +755,6 @@
     "createdAt": 1770665412,
     "platformId": "kumbaya",
     "assets": ["WETH", "USDm"],
-    "pointStructureIds": ["megaeth-terminal"],
     "risks": {
       "complex": true,
       "curated": false,


### PR DESCRIPTION
## Summary
- MegaETH Terminal points campaign has ended.
- Removes the `pointStructureIds` from the 3 eligible vaults in `src/config/vault/megaeth.json` and the corresponding `megaeth-terminal` entry from `src/config/points.json`.
- Banner + Points chip auto-disappear from the affected vaults (both derive from `pointStructureIds`).
- Underlying banner infrastructure (Redux slice, selectors, component, theme tokens) is untouched so the next program is config-only again.

## Test plan
- [ ] No "Points by MegaETH Terminal" banner on `kumbaya-cow-megaeth-weth-usdm-rp`, `kumbaya-cow-megaeth-mega-usdm-rp`, `prism-cow-megaeth-mega-usdm-rp`.
- [ ] No `Points` chip on the same vaults' list rows or detail header.
- [ ] `npm run validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)