### PR TITLE
fix: center NEW badge over chain icon on homepage filter

### DIFF
--- a/src/features/home/components/Filters/components/ChainFilters/styles.ts
+++ b/src/features/home/components/Filters/components/ChainFilters/styles.ts
@@ -45,8 +45,9 @@ export const styles = {
     zIndex: 'badge',
     md: {
       marginTop: '-32px',
-      marginLeft: '-8px',
-      left: '0',
+      marginLeft: '0',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
     },
   }),
   active: css.raw({


### PR DESCRIPTION
Badge was anchored to the button's left edge with a hand-tuned `marginLeft: -8px`, which left it ~2.5px short of the icon center. Replaced with `left: 50%` + `translate(-50%, -50%)` so the badge self-centers regardless of badge text width or button width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)