### PR TITLE
fix: extended filters dropdown gap when flipped upward

### DIFF
--- a/src/features/home/components/Filters/components/ExtendedFilters/ExtendedFiltersButtonDropdown.tsx
+++ b/src/features/home/components/Filters/components/ExtendedFilters/ExtendedFiltersButtonDropdown.tsx
@@ -50,7 +50,8 @@ export const ExtendedFiltersButtonDropdown = memo(function ExtendedFiltersButton
     onOpenChange,
     middleware: [
       offset(8),
-      flip({ padding: 12, crossAxis: true, fallbackAxisSideDirection: 'start' }),
+      // vertical-only flip; a side-axis fallback would detach the panel from the button
+      flip({ padding: 12, crossAxis: true }),
       shift({ padding: 12 }),
     ],
   });

--- a/src/features/home/components/Filters/components/ExtendedFilters/ExtendedFiltersButtonDropdown.tsx
+++ b/src/features/home/components/Filters/components/ExtendedFilters/ExtendedFiltersButtonDropdown.tsx
@@ -39,7 +39,7 @@ export const ExtendedFiltersButtonDropdown = memo(function ExtendedFiltersButton
     [setIsOpen, dispatch]
   );
 
-  const { context, refs, floatingStyles } = useFloating<HTMLButtonElement>({
+  const { context, refs, floatingStyles, placement } = useFloating<HTMLButtonElement>({
     placement: 'bottom-end',
     whileElementsMounted(referenceEl, floatingEl, update) {
       return autoUpdate(referenceEl, floatingEl, update, {
@@ -79,6 +79,7 @@ export const ExtendedFiltersButtonDropdown = memo(function ExtendedFiltersButton
           <FiltersDropdownOuter
             ref={refs.setFloating}
             style={floatingStyles}
+            data-placement={placement.startsWith('top') ? 'top' : 'bottom'}
             {...getFloatingProps()}
           >
             <FiltersDropdownInner>
@@ -120,6 +121,13 @@ const FiltersDropdownOuter = styled(DropdownOuter, {
   base: {
     // should match height of highest possible content
     height: '390px',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+    // opened upward: bottom-align so the panel hugs the button instead of leaving a gap
+    '&[data-placement="top"]': {
+      justifyContent: 'flex-end',
+    },
   },
 });
 
@@ -128,6 +136,8 @@ const FiltersDropdownInner = styled(
   {
     base: {
       width: '340px',
+      // Platforms view is a near-exact 390px fit; keep it from compressing as a flex child
+      flexShrink: 0,
     },
   },
   {


### PR DESCRIPTION
The "More filters" dropdown reserves a fixed height for its tallest sub-view (the Platforms list). When `flip` placed it **above** the button the top-aligned panel left a visible gap; and when neither side had room, flip's side-axis fallback placed it *beside* the button where it read as fully detached.

Fix: bottom-align the panel on upward placement so it hugs the button, and keep flip on the vertical axis (drop the side-axis fallback) so it always stays anchored to the trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)