### PR TITLE
fix: dashboard flashing empty state during initial load

### DIFF
--- a/src/features/data/selectors/analytics.ts
+++ b/src/features/data/selectors/analytics.ts
@@ -41,6 +41,8 @@ import {
   selectUserDepositedVaultIds,
   selectUserVaultBalanceInShareTokenIncludingDisplaced,
 } from './balance.ts';
+import { selectAllChainIds } from './chains.ts';
+import { selectHasBalanceSettledForChainUser } from './data-loader/balance.ts';
 import { selectIsConfigAvailable } from './data-loader/config.ts';
 import { hasLoaderFulfilledOnce } from './data-loader-helpers.ts';
 import { selectFeesByVaultId } from './fees.ts';
@@ -157,8 +159,12 @@ export const selectIsDashboardDataLoadedByAddress = (state: BeefyState, walletAd
 
   // do not wait if user has no deposits and fetch wallet timeline has not dispatched
   // [as we don't dispatch fetch wallet timeline for users with no deposits]
+  // "no deposits" can only be trusted once every chain's balance has settled,
+  // as until then deposits may exist on a chain we have not checked yet
   if (!hasDepositedVaults && timelineIdle) {
-    return true;
+    return selectAllChainIds(state).every(chainId =>
+      selectHasBalanceSettledForChainUser(state, chainId, addressLower)
+    );
   }
 
   return selectIsAnalyticsLoadedByAddress(state, addressLower);


### PR DESCRIPTION
On dashboard load the page briefly rendered a fully-loaded "no deposits" state between two spinners: `selectIsDashboardDataLoadedByAddress` trusted "no deposits + timeline idle" as soon as the first chain's balance arrived, before the deposited-vaults recalc and timeline fetch had caught up. The early-exit now only fires once every chain's balance has settled, so the dashboard stays on the loader until "no deposits" is actually proven. Trade-off: genuinely empty addresses wait for the slowest chain before showing the empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)