### PR TITLE
[fix] v2v strategy lifecycle hooks

### DIFF
--- a/src/features/data/apis/transact/handlers/vault/VaultDestHandler.ts
+++ b/src/features/data/apis/transact/handlers/vault/VaultDestHandler.ts
@@ -44,6 +44,7 @@ export class VaultDestHandler implements IDestHandler<VaultDestState> {
       );
     }
 
+    await match.strategy.beforeQuote?.();
     const destQuote = await match.strategy.fetchDepositQuote(
       [{ token: ctx.inputToken, amount: inputAmount, max: false }],
       match.option
@@ -91,6 +92,7 @@ export class VaultDestHandler implements IDestHandler<VaultDestState> {
       );
     }
 
+    await destStrategy.beforeStep?.();
     const breakdown = await destStrategy.fetchDepositUserlessZapBreakdown(destQuote);
     return {
       zapSteps: breakdown.zapRequest.steps,

--- a/src/features/data/apis/transact/handlers/vault/VaultSourceHandler.ts
+++ b/src/features/data/apis/transact/handlers/vault/VaultSourceHandler.ts
@@ -56,8 +56,9 @@ export class VaultSourceHandler implements ISourceHandler<VaultSourceState> {
       );
     }
 
-    const adaptedInput = this.adaptInputToStrategy(input, match, srcHelpers.getState());
     await match.strategy.beforeQuote?.();
+
+    const adaptedInput = this.adaptInputToStrategy(input, match, srcHelpers.getState());
     const underlyingQuote = await match.strategy.fetchWithdrawQuote([adaptedInput], match.option);
     if (!isZapQuote(underlyingQuote)) {
       throw new Error(

--- a/src/features/data/apis/transact/handlers/vault/VaultSourceHandler.ts
+++ b/src/features/data/apis/transact/handlers/vault/VaultSourceHandler.ts
@@ -57,6 +57,7 @@ export class VaultSourceHandler implements ISourceHandler<VaultSourceState> {
     }
 
     const adaptedInput = this.adaptInputToStrategy(input, match, srcHelpers.getState());
+    await match.strategy.beforeQuote?.();
     const underlyingQuote = await match.strategy.fetchWithdrawQuote([adaptedInput], match.option);
     if (!isZapQuote(underlyingQuote)) {
       throw new Error(
@@ -108,6 +109,7 @@ export class VaultSourceHandler implements ISourceHandler<VaultSourceState> {
       );
     }
 
+    await strategy.beforeStep?.();
     const breakdown = await strategy.fetchWithdrawUserlessZapBreakdown(underlyingQuote);
 
     return {

--- a/src/features/data/apis/transact/strategies/gov/GovComposerStrategy.ts
+++ b/src/features/data/apis/transact/strategies/gov/GovComposerStrategy.ts
@@ -131,6 +131,16 @@ class GovComposerStrategyImpl implements IComposerStrategy<StrategyId> {
     return this.underlyingStrategy.canEmitTokenAsWithdraw(token);
   }
 
+  async beforeQuote(): Promise<void> {
+    await this.underlyingStrategy.beforeQuote?.();
+    await this.dualUnderlying?.beforeQuote?.();
+  }
+
+  async beforeStep(): Promise<void> {
+    await this.underlyingStrategy.beforeStep?.();
+    await this.dualUnderlying?.beforeStep?.();
+  }
+
   async fetchDepositOptions(): Promise<GovComposerDepositOption[]> {
     const [primaryOptions, dualOptions] = await Promise.all([
       this.underlyingStrategy.fetchDepositOptions(),

--- a/src/features/data/apis/transact/strategies/vault/VaultComposerStrategy.ts
+++ b/src/features/data/apis/transact/strategies/vault/VaultComposerStrategy.ts
@@ -111,6 +111,16 @@ class VaultComposerStrategyImpl implements IComposerStrategy<StrategyId> {
     return this.underlyingStrategy.canEmitTokenAsWithdraw(token);
   }
 
+  async beforeQuote(): Promise<void> {
+    await this.underlyingStrategy.beforeQuote?.();
+    await this.dualUnderlying?.beforeQuote?.();
+  }
+
+  async beforeStep(): Promise<void> {
+    await this.underlyingStrategy.beforeStep?.();
+    await this.dualUnderlying?.beforeStep?.();
+  }
+
   async fetchDepositOptions(): Promise<VaultComposerDepositOption[]> {
     const [primaryOptions, dualOptions] = await Promise.all([
       this.underlyingStrategy.fetchDepositOptions(),


### PR DESCRIPTION
call beforeQuote/beforeStep on underlying/composed strategies. This was preventing v2v from working on vaults requiring this such as Gamma