### PR TITLE
feat: rotate spotlight featured vaults for equal exposure

### DIFF
--- a/src/features/data/actions/promos.ts
+++ b/src/features/data/actions/promos.ts
@@ -1,5 +1,5 @@
-import { sortBy } from 'lodash-es';
 import { getUnixNow } from '../../../helpers/date.ts';
+import { seededShuffle } from '../../../helpers/random.ts';
 import type { VaultConfig } from '../apis/config-types.ts';
 import { getPromosApi } from '../apis/promos/promos.ts';
 import type { PinnedConfig, PinnedConfigCondition, PromoConfig } from '../apis/promos/types.ts';
@@ -196,19 +196,6 @@ function selectVaultMatchesAnyCondition(
   return conditions.some(condition => selectVaultMatchesCondition(state, vaultId, condition));
 }
 
-function makePRNG(seed: number) {
-  // SplitMix32
-  return function () {
-    seed |= 0;
-    seed = (seed + 0x9e3779b9) | 0;
-    let num = seed ^ (seed >>> 16);
-    num = Math.imul(num, 0x21f0aaad);
-    num = num ^ (num >>> 15);
-    num = Math.imul(num, 0x735a2d97);
-    return ((num = num ^ (num >>> 15)) >>> 0) / 4294967296;
-  };
-}
-
 function limitIds(ids: string[], limit: number | undefined, periodSeconds: number = 21600) {
   if (limit === undefined) {
     return ids;
@@ -221,8 +208,7 @@ function limitIds(ids: string[], limit: number | undefined, periodSeconds: numbe
   }
 
   ids.sort();
-  const rng = makePRNG(Math.floor(Date.now() / (periodSeconds * 1000)));
-  const sorted = sortBy(ids, () => rng());
+  const sorted = seededShuffle(ids, Math.floor(Date.now() / (periodSeconds * 1000)));
   return sorted.slice(0, limit);
 }
 

--- a/src/features/home/components/FeaturedVaults/FeaturedVaults.tsx
+++ b/src/features/home/components/FeaturedVaults/FeaturedVaults.tsx
@@ -1,10 +1,16 @@
 import { styled } from '@repo/styles/jsx';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMediaQuery } from '../../../../hooks/useMediaQuery.ts';
+import { seededShuffle } from '../../../../helpers/random.ts';
 import { FeaturedVaultCard } from '../FeaturedVaultCard/FeaturedVaultCard.tsx';
 import { selectFeaturedVaultIds } from '../../../data/selectors/featured-vaults.ts';
 import { useAppSelector } from '../../../data/store/hooks.ts';
+
+// Reshuffle the featured order on a time cadence so revisits lead with a different set,
+// spreading prime visibility across all featured vaults. Deterministic within a window
+// (stable on reload, same for everyone), frozen per mount so cards never re-order mid-read.
+const ROTATION_PERIOD_SECONDS = 60;
 
 const DRAG_THRESHOLD_PX = 5;
 // Keep in sync with the `columnGap` on Scroller below.
@@ -21,7 +27,12 @@ const MEDIA_DESKTOP = '(min-width: 960px)';
 
 export const FeaturedVaults = memo(function FeaturedVaults() {
   const { t } = useTranslation();
-  const ids = useAppSelector(selectFeaturedVaultIds);
+  const featuredIds = useAppSelector(selectFeaturedVaultIds);
+  const [seed] = useState(() => Math.floor(Date.now() / (ROTATION_PERIOD_SECONDS * 1000)));
+  const ids = useMemo(
+    () => (featuredIds.length <= 1 ? featuredIds : seededShuffle(featuredIds, seed)),
+    [featuredIds, seed]
+  );
   const isSideBySide = useMediaQuery(MEDIA_SIDE_BY_SIDE);
   const isTablet = useMediaQuery(MEDIA_TABLET);
   const isDesktop = useMediaQuery(MEDIA_DESKTOP);

--- a/src/helpers/random.ts
+++ b/src/helpers/random.ts
@@ -1,0 +1,26 @@
+import { sortBy } from 'lodash-es';
+
+/**
+ * SplitMix32 PRNG — returns a function yielding deterministic floats in [0, 1) for a given seed.
+ * Same seed always produces the same sequence, so it can drive reproducible shuffles.
+ */
+function makePRNG(seed: number) {
+  return function () {
+    seed |= 0;
+    seed = (seed + 0x9e3779b9) | 0;
+    let num = seed ^ (seed >>> 16);
+    num = Math.imul(num, 0x21f0aaad);
+    num = num ^ (num >>> 15);
+    num = Math.imul(num, 0x735a2d97);
+    return ((num = num ^ (num >>> 15)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Return a new array with `items` shuffled deterministically from `seed` (input left untouched).
+ * Same seed + same items always produce the same order.
+ */
+export function seededShuffle<T>(items: T[], seed: number): T[] {
+  const rng = makePRNG(seed);
+  return sortBy(items, () => rng());
+}


### PR DESCRIPTION
With 7 featured vaults but only ~4 visible at once, the last few never got prime visibility. The Spotlight order is now shuffled deterministically per 60s window (frozen per mount, so it never re-orders mid-view), spreading prime placement across all featured vaults on reload/revisit. Extracts the seeded-shuffle helper already used by the pinned-vaults logic into `helpers/random.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)