### PR TITLE
fix(clm): correct date in fees graph tooltip

### DIFF
--- a/src/features/vault/components/PnLGraph/cowcentrated/components/Tooltips/Tooltips.tsx
+++ b/src/features/vault/components/PnLGraph/cowcentrated/components/Tooltips/Tooltips.tsx
@@ -124,7 +124,7 @@ export const FeesTooltip = memo(function FeesTooltip({
 
   return (
     <div className={classes.content}>
-      <div>{formatDateTime(timestamp * 1000)}</div>
+      <div>{formatDateTime(timestamp)}</div>
       {tokens.map((token, i) => (
         <div className={classes.itemContainer} key={token.id}>
           <div className={classes.label}>{token.symbol}:</div>

--- a/src/helpers/graph/timeseries.ts
+++ b/src/helpers/graph/timeseries.ts
@@ -175,6 +175,7 @@ function advanceIndexIfNeeded<
 }
 
 export type ClmInvestorOverviewTimeSeriesPoint = {
+  /** unix timestamp in milliseconds */
   timestamp: number;
   shares: number;
   underlying: number;
@@ -739,6 +740,7 @@ export function getClmInvestorTimeSeries(
 }
 
 export type ClmInvestorFeesTimeSeriesPoint = {
+  /** unix timestamp in milliseconds */
   t: number;
   /** cumulative usd per token */
   values: number[];


### PR DESCRIPTION
The CLM fees tooltip multiplied an already-milliseconds timestamp by 1000, so
hovering rendered dates in the year ~58000. Drops the extra conversion and
documents the units on both emitted point types, since the internal `t` is
seconds and the emitted `t` is milliseconds.

Visible on the vault Fees tab and the dashboard Compounds Chart. Introduced in
5d73e015d — the axis on the same chart reads the field unscaled and was always
correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)