### PR TITLE
feat: extend CLM not-calm auto-retry to withdraw and migrate flows

### DIFF
--- a/src/features/data/selectors/transact.ts
+++ b/src/features/data/selectors/transact.ts
@@ -122,6 +122,8 @@ export const selectTransactInputIndexMax = (state: BeefyState, index: number) =>
 
 export const selectTransactSelectedChainId = (state: BeefyState) =>
   state.ui.transact.selectedChainId;
+export const selectTransactSelectedSelectionIdOrUndefined = (state: BeefyState) =>
+  state.ui.transact.selectedSelectionId;
 export const selectTransactSelectedSelectionId = (state: BeefyState) =>
   valueOrThrow(state.ui.transact.selectedSelectionId, 'No selected selection id found');
 export const selectTransactSelectedQuoteId = (state: BeefyState) =>

--- a/src/features/vault/components/Actions/Transact/MigrateActions/MigrateActions.tsx
+++ b/src/features/vault/components/Actions/Transact/MigrateActions/MigrateActions.tsx
@@ -1,10 +1,9 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { styled } from '@repo/styles/jsx';
 import { AnimatedButton } from '../../../../../../components/Button/AnimatedButton.tsx';
 import { Button } from '../../../../../../components/Button/Button.tsx';
 import { AlertError } from '../../../../../../components/Alerts/Alerts.tsx';
-import { ExternalLink } from '../../../../../../components/Links/ExternalLink.tsx';
 import { useAppDispatch, useAppSelector } from '../../../../../data/store/hooks.ts';
 import {
   transactClearQuotes,
@@ -46,6 +45,8 @@ import { selectVaultById } from '../../../../../data/selectors/vaults.ts';
 import { ActionConnectSwitch } from '../CommonActions/CommonActions.tsx';
 import { ConfirmNotice } from '../ConfirmNotice/ConfirmNotice.tsx';
 import { PriceImpactNotice } from '../PriceImpactNotice/PriceImpactNotice.tsx';
+import { CalmAlert } from '../TransactQuote/TransactQuote.tsx';
+import { NOT_CALM_REFRESH_SECONDS, useNotCalmAutoRefresh } from '../hooks/useNotCalmAutoRefresh.ts';
 import { ZapRoute, ZapRoutePlaceholder } from '../ZapRoute/ZapRoute.tsx';
 import { ZapSlippage } from '../ZapSlippage/ZapSlippage.tsx';
 import { VaultFees } from '../VaultFees/VaultFees.tsx';
@@ -85,6 +86,7 @@ export const MigrateActions = memo(function MigrateActions({
 
   const [isDisabledByConfirm, setIsDisabledByConfirm] = useState(false);
   const [isDisabledByPriceImpact, setIsDisabledByPriceImpact] = useState(false);
+  const { stickyNotCalmAction, showNotCalmRefresh } = useNotCalmAutoRefresh();
 
   const fetchQuote = useCallback(() => {
     dispatch(transactFetchQuotes());
@@ -149,6 +151,12 @@ export const MigrateActions = memo(function MigrateActions({
   const isLoading = isExecuting || isStepping;
   const isQuotePending = quoteStatus === TransactStatus.Pending;
   const hasQuote = quoteStatus === TransactStatus.Fulfilled && !!quote;
+  // keep the refresh control mounted while retrying not-calm, even when the countdown is paused
+  const notCalmRetrying =
+    !!stickyNotCalmAction ||
+    (quoteStatus === TransactStatus.Rejected &&
+      !!quoteError &&
+      QuoteCowcentratedNotCalmError.match(quoteError));
 
   if (hasQuote && isZapQuote(quote)) {
     return (
@@ -188,9 +196,21 @@ export const MigrateActions = memo(function MigrateActions({
 
   return (
     <>
-      <ZapRoutePlaceholder />
+      <ZapRoutePlaceholder
+        enableRefresh={
+          notCalmRetrying ?
+            isQuotePending ?
+              'disabled'
+            : true
+          : false
+        }
+        autoRefresh={showNotCalmRefresh}
+        autoRefreshSeconds={NOT_CALM_REFRESH_SECONDS}
+      />
       {quoteStatus === TransactStatus.Rejected && quoteError ?
         <MigrateQuoteError error={quoteError} />
+      : stickyNotCalmAction ?
+        <CalmAlert i18nKey={`Transact-Quote-Error-Calm-Retry-${stickyNotCalmAction}`} />
       : null}
       <ActionsContainer>
         <ActionConnectSwitch chainId={newVault.chainId}>
@@ -228,19 +248,7 @@ const MigrateQuoteError = memo(function MigrateQuoteError({
     );
   }
   if (error && QuoteCowcentratedNotCalmError.match(error)) {
-    return (
-      <AlertError>
-        <Trans
-          t={t}
-          i18nKey={`Transact-Quote-Error-Calm-${error.action}`}
-          components={{
-            LinkCalm: (
-              <CalmLink href="https://docs.beefy.finance/beefy-products/clm#calmness-check" />
-            ),
-          }}
-        />
-      </AlertError>
-    );
+    return <CalmAlert i18nKey={`Transact-Quote-Error-Calm-Retry-${error.action}`} />;
   }
 
   return (
@@ -259,12 +267,5 @@ const ActionsContainer = styled('div', {
     flexDirection: 'column',
     backgroundColor: 'background.content.light',
     borderRadius: '8px',
-  },
-});
-
-const CalmLink = styled(ExternalLink, {
-  base: {
-    color: 'text.lightest',
-    textDecoration: 'underline',
   },
 });

--- a/src/features/vault/components/Actions/Transact/TransactQuote/TransactQuote.tsx
+++ b/src/features/vault/components/Actions/Transact/TransactQuote/TransactQuote.tsx
@@ -93,7 +93,7 @@ export const TransactQuote = memo(function TransactQuote({
     () => inputAmounts.every(amount => amount.lte(BIG_ZERO)),
     [inputAmounts]
   );
-  const { showStickyNotCalmWarning, showNotCalmRefresh } = useNotCalmAutoRefresh();
+  const { stickyNotCalmAction, showNotCalmRefresh } = useNotCalmAutoRefresh();
 
   const debouncedFetchQuotes = useMemo(
     () =>
@@ -168,8 +168,8 @@ export const TransactQuote = memo(function TransactQuote({
         <QuoteFulfilledBody />
       : status === TransactStatus.Idle ?
         <QuoteIdleBody vault={vault} mode={mode} />
-      : showStickyNotCalmWarning ?
-        <CalmAlert i18nKey="Transact-Quote-Error-Calm-deposit" variant="warning" />
+      : stickyNotCalmAction ?
+        <CalmAlert i18nKey={`Transact-Quote-Error-Calm-Retry-${stickyNotCalmAction}`} />
       : status === TransactStatus.Pending ?
         <TokenAmountIconLoader />
       : <QuoteError />}
@@ -252,17 +252,16 @@ const QuoteIdleBody = memo(function QuoteIdleBody({ vault, mode }: QuoteIdleBody
 
 type CalmAlertProps = {
   i18nKey: string;
-  variant: 'warning' | 'error';
 };
-const CalmAlert = memo(function CalmAlert({ i18nKey, variant }: CalmAlertProps) {
+export const CalmAlert = memo(function CalmAlert({ i18nKey }: CalmAlertProps) {
   const { t } = useTranslation();
   const classes = useStyles();
-  const Alert = variant === 'warning' ? AlertWarning : AlertError;
   return (
-    <Alert>
+    <AlertWarning>
       <Trans
         t={t}
         i18nKey={i18nKey}
+        values={{ interval: NOT_CALM_REFRESH_SECONDS }}
         components={{
           LinkCalm: (
             <ExternalLink
@@ -272,7 +271,7 @@ const CalmAlert = memo(function CalmAlert({ i18nKey, variant }: CalmAlertProps) 
           ),
         }}
       />
-    </Alert>
+    </AlertWarning>
   );
 });
 
@@ -297,12 +296,7 @@ const QuoteError = memo(function QuoteError() {
       );
     }
     if (QuoteCowcentratedNotCalmError.match(error)) {
-      return (
-        <CalmAlert
-          i18nKey={`Transact-Quote-Error-Calm-${error.action}`}
-          variant={error.action === 'deposit' ? 'warning' : 'error'}
-        />
-      );
+      return <CalmAlert i18nKey={`Transact-Quote-Error-Calm-Retry-${error.action}`} />;
     }
   }
 

--- a/src/features/vault/components/Actions/Transact/ZapRoute/ZapRoute.tsx
+++ b/src/features/vault/components/Actions/Transact/ZapRoute/ZapRoute.tsx
@@ -49,6 +49,7 @@ import {
 } from '../../../../../data/selectors/transact.ts';
 import { selectZapSwapProviderName } from '../../../../../data/selectors/zap.ts';
 import { QuoteTitle } from '../QuoteTitle/QuoteTitle.tsx';
+import type { ReloadSpinnerState } from '../../../../../../components/ReloadSpinner/ReloadSpinner.tsx';
 import { QuoteTitleRefresh } from '../QuoteTitleRefresh/QuoteTitleRefresh.tsx';
 import { ProviderIcon } from '../ProviderIcon/ProviderIcon.tsx';
 import ExpandMore from '../../../../../../images/icons/mui/ExpandMore.svg?react';
@@ -707,14 +708,27 @@ export const ZapRoute = memo(function ZapRoute({
 
 export type ZapRoutePlaceholderProps = {
   css?: CssStyles;
+  enableRefresh?: ReloadSpinnerState;
+  autoRefresh?: boolean;
+  autoRefreshSeconds?: number;
 };
 export const ZapRoutePlaceholder = memo(function ZapRoutePlaceholder({
   css: cssProp,
+  enableRefresh = false,
+  autoRefresh = false,
+  autoRefreshSeconds,
 }: ZapRoutePlaceholderProps) {
   const { t } = useTranslation();
   return (
     <div className={css(cssProp)}>
-      <div className={css(styles.title)}>{t('Transact-ZapRoute')}</div>
+      {enableRefresh !== false ?
+        <QuoteTitleRefresh
+          title={t('Transact-ZapRoute')}
+          enableRefresh={enableRefresh}
+          autoRefresh={autoRefresh}
+          autoRefreshSeconds={autoRefreshSeconds}
+        />
+      : <div className={css(styles.title)}>{t('Transact-ZapRoute')}</div>}
       <div className={css(styles.routeHolder, styles.routeHolderDisabled)}>
         <div className={css(styles.routeHeader, styles.routeHeaderDisabled)}>
           <div className={css(styles.placeholderTitle)}>

--- a/src/features/vault/components/Actions/Transact/hooks/useNotCalmAutoRefresh.ts
+++ b/src/features/vault/components/Actions/Transact/hooks/useNotCalmAutoRefresh.ts
@@ -7,9 +7,9 @@ import {
   selectTransactMode,
   selectTransactQuoteError,
   selectTransactQuoteStatus,
-  selectTransactSelected,
   selectTransactSelectedChainId,
-  selectTransactSelectedSelectionId,
+  selectTransactSelectedSelectionIdOrUndefined,
+  selectTransactSelectionById,
 } from '../../../../../data/selectors/transact.ts';
 import { selectIsWindowFocused } from '../../../../../data/selectors/window.ts';
 import { useAppSelector } from '../../../../../data/store/hooks.ts';
@@ -17,14 +17,14 @@ import { useAppSelector } from '../../../../../data/store/hooks.ts';
 export const NOT_CALM_REFRESH_SECONDS = 10;
 
 export type NotCalmAutoRefresh = {
-  /** Keep the calm warning visible while a not-calm retry re-quote is in flight (no loader flicker). */
-  showStickyNotCalmWarning: boolean;
-  /** Run the title's auto-refresh countdown while we're retrying a not-calm deposit. */
+  /** Action of the not-calm retry re-quote in flight — keeps the calm warning visible (no loader flicker). */
+  stickyNotCalmAction: 'deposit' | 'withdraw' | undefined;
+  /** Run the title's auto-refresh countdown while we're retrying a not-calm quote. */
   showNotCalmRefresh: boolean;
 };
 
 /**
- * CLM "not calm" deposit auto-refresh. When a deposit quote fails the on-chain calmness check we
+ * CLM "not calm" auto-refresh. When a deposit/withdraw quote fails the on-chain calmness check we
  * re-quote every NOT_CALM_REFRESH_SECONDS until a calm quote comes back. The countdown ring AND the
  * re-quote itself are driven by ReloadSpinner (it fires onClick when the countdown completes), so
  * all we need here is the retrying flag — paused while the tab is backgrounded so we don't re-quote
@@ -35,29 +35,30 @@ export type NotCalmAutoRefresh = {
 export function useNotCalmAutoRefresh(): NotCalmAutoRefresh {
   const mode = useAppSelector(selectTransactMode);
   const isWindowFocused = useAppSelector(selectIsWindowFocused);
-  const selectionId = useAppSelector(selectTransactSelectedSelectionId);
-  const selection = useAppSelector(selectTransactSelected);
+  // reset-trigger deps only — must not throw before a selection exists (e.g. migrate flow)
+  const selectionId = useAppSelector(selectTransactSelectedSelectionIdOrUndefined);
+  const selection = useAppSelector(state =>
+    selectionId ? selectTransactSelectionById(state, selectionId) : undefined
+  );
   const inputAmounts = useAppSelector(selectTransactInputAmounts);
   const inputMaxes = useAppSelector(selectTransactInputMaxes);
   const chainId = useAppSelector(selectTransactSelectedChainId);
   const status = useAppSelector(selectTransactQuoteStatus);
   const quoteError = useAppSelector(selectTransactQuoteError);
 
-  const isNotCalmDepositError =
-    !!quoteError &&
-    QuoteCowcentratedNotCalmError.match(quoteError) &&
-    quoteError.action === 'deposit';
+  const notCalmAction =
+    quoteError && QuoteCowcentratedNotCalmError.match(quoteError) ? quoteError.action : undefined;
 
-  // True from the first not-calm error until any other settled result (calm quote, different error,
-  // or idle). Stays true across the retry's brief Pending so the warning doesn't flicker to a loader.
-  const [retrying, setRetrying] = useState(false);
+  // Set from the first not-calm error until any other settled result (calm quote, different error,
+  // or idle). Persists across the retry's brief Pending so the warning doesn't flicker to a loader.
+  const [retryingAction, setRetryingAction] = useState<'deposit' | 'withdraw' | undefined>();
   useEffect(() => {
-    if (isNotCalmDepositError) {
-      setRetrying(true);
+    if (notCalmAction) {
+      setRetryingAction(notCalmAction);
     } else if (status !== TransactStatus.Pending) {
-      setRetrying(false);
+      setRetryingAction(undefined);
     }
-  }, [isNotCalmDepositError, status]);
+  }, [notCalmAction, status]);
 
   // Reset whenever the user changes what they're transacting.
   const skipInitialReset = useRef(true);
@@ -66,11 +67,12 @@ export function useNotCalmAutoRefresh(): NotCalmAutoRefresh {
       skipInitialReset.current = false;
       return;
     }
-    setRetrying(false);
+    setRetryingAction(undefined);
   }, [chainId, inputAmounts, inputMaxes, mode, selection, selectionId]);
 
   return {
-    showStickyNotCalmWarning: status === TransactStatus.Pending && retrying,
-    showNotCalmRefresh: retrying && isWindowFocused,
+    stickyNotCalmAction: status === TransactStatus.Pending ? retryingAction : undefined,
+    // pause the countdown while a re-quote is in flight so a slow quote isn't discarded by the next tick
+    showNotCalmRefresh: !!retryingAction && isWindowFocused && status !== TransactStatus.Pending,
   };
 }

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -810,6 +810,8 @@
   "Transact-Quote-Error": "There was an error fetching quotes",
   "Transact-Quote-Error-Calm-deposit": "New deposits are temporarily unavailable as the current price is outside the <LinkCalm>calm zone</LinkCalm>. Please wait a few minutes and try again.",
   "Transact-Quote-Error-Calm-withdraw": "Withdraws are temporarily unavailable as the current price is outside the <LinkCalm>calm zone</LinkCalm>. Please wait a few minutes and try again.",
+  "Transact-Quote-Error-Calm-Retry-deposit": "Deposits are temporarily unavailable as the current price is outside the <LinkCalm>calm zone</LinkCalm>. Deposits will resume automatically once it's back in range — we check every {{interval}} seconds, or refresh to check now.",
+  "Transact-Quote-Error-Calm-Retry-withdraw": "Withdrawals are temporarily unavailable as the current price is outside the <LinkCalm>calm zone</LinkCalm>. Withdrawals will resume automatically once it's back in range — we check every {{interval}} seconds, or refresh to check now.",
   "Transact-Quote-Error-CrossChain-TooLow-deposit": "Selected amount is too low to start a cross-chain deposit. Increase the amount and try again.",
   "Transact-Quote-Error-CrossChain-TooLow-withdraw": "Selected amount is too low to start a cross-chain withdrawal. Increase the amount and try again.",
   "Transact-Notice-PriceImpact": "Price impact on this zap is {{priceImpact}}",


### PR DESCRIPTION
Withdraw and migrate flows showed a terminal red error when a CLM was outside the calm zone, while deposits auto-retried. Both now get the same amber warning with the 10s auto-refresh countdown, with updated copy stating the retry cadence. Also pauses the countdown while a re-quote is in flight (previously a slow quote could be discarded by the next tick, deposits included) and fixes a crash on vaults with a migration section from a throwing selection selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)