### PR TITLE
fix apy sub sort

### DIFF
--- a/src/features/data/reducers/filtered-vaults.test.ts
+++ b/src/features/data/reducers/filtered-vaults.test.ts
@@ -99,11 +99,17 @@ describe('sortPickedDuringSearch transitions', () => {
       filteredVaultsActions.update({ sort: 'apy' }),
       filteredVaultsActions.update({ sortDirection: 'asc' }),
       filteredVaultsActions.update({ sort: 'tvl', sortDirection: 'desc' }),
-      // subSort only takes effect under the apy sort, so pick it alongside
-      filteredVaultsActions.update({ sort: 'apy', subSort: { apy: 30 } }),
     ]) {
       expect(reducer(searching, action).sortPickedDuringSearch).toBe(true);
     }
+  });
+
+  it('changing a sub-sort alone is not a sort pick', () => {
+    const searching = reducer(initial, filteredVaultsActions.update({ searchText: 'eth' }));
+    const state = reducer(searching, filteredVaultsActions.update({ subSort: { apy: 30 } }));
+    expect(state.sortPickedDuringSearch).toBe(false);
+    expect(relevance(state)).toBe(true);
+    expect(state.pending.subSort.apy).toBe(30);
   });
 
   it('picking a sort while NOT searching does not mark the pick', () => {

--- a/src/features/data/reducers/filtered-vaults.ts
+++ b/src/features/data/reducers/filtered-vaults.ts
@@ -35,7 +35,6 @@ export const filteredVaultsSlice = createSlice({
       const prevSearchText = sliceState.pending.searchText;
       const prevSort = sliceState.pending.sort;
       const prevSortDirection = sliceState.pending.sortDirection;
-      const prevSubSortApy = sliceState.pending.subSort.apy;
       const next = mergePreset(sliceState.pending, action.payload);
       sliceState.pending = next;
 
@@ -47,10 +46,7 @@ export const filteredVaultsSlice = createSlice({
         sliceState.sortPickedDuringSearch = false;
       }
       // an explicit sort while searching disables the relevance override
-      const sortChanged =
-        next.sort !== prevSort ||
-        next.sortDirection !== prevSortDirection ||
-        next.subSort.apy !== prevSubSortApy;
+      const sortChanged = next.sort !== prevSort || next.sortDirection !== prevSortDirection;
       if (sortChanged && hasSearchText(next.searchText)) {
         sliceState.sortPickedDuringSearch = true;
       }

--- a/src/features/data/utils/filter-values.test.ts
+++ b/src/features/data/utils/filter-values.test.ts
@@ -29,6 +29,25 @@ describe('mergePreset onlyUnstakedClm', () => {
   });
 });
 
+describe('mergePreset subSort', () => {
+  it('survives a sort change to another column', () => {
+    const base = { ...FILTER_DEFAULTS, sort: 'apy' as const, subSort: { apy: 30 as const } };
+    expect(mergePreset(base, { sort: 'tvl' }).subSort.apy).toBe(30);
+  });
+
+  it('applies under a sort that has no sub-sort of its own', () => {
+    const base = { ...FILTER_DEFAULTS, sort: 'tvl' as const };
+    expect(mergePreset(base, { subSort: { apy: 30 } }).subSort.apy).toBe(30);
+  });
+
+  it('does not promote sort to the sub-sort parent (callers decide that)', () => {
+    const base = { ...FILTER_DEFAULTS, sort: 'tvl' as const, subSort: { apy: 7 as const } };
+    const merged = mergePreset(base, { subSort: { apy: 'default' } });
+    expect(merged.subSort.apy).toBe('default');
+    expect(merged.sort).toBe('tvl');
+  });
+});
+
 describe('filtersDependOnData', () => {
   function withFilters(values: Partial<FilterValues>): FilterValues {
     return { ...FILTER_DEFAULTS, ...values };

--- a/src/features/data/utils/filter-values.ts
+++ b/src/features/data/utils/filter-values.ts
@@ -46,10 +46,6 @@ export function mergePreset(
     ...rest,
     subSort: { ...base.subSort, ...subSort },
   };
-  // fix subSort vs sort
-  if (merged.sort !== 'apy' && merged.subSort.apy !== 'default') {
-    merged.subSort = { ...merged.subSort, apy: 'default' };
-  }
   // changing user category drops the unstaked clm filter, unless the preset sets it explicitly
   if (preset.userCategory !== undefined && preset.onlyUnstakedClm === undefined) {
     merged.onlyUnstakedClm = false;

--- a/src/features/home/components/FeaturedVaultCard/FeaturedVaultApyLabel.tsx
+++ b/src/features/home/components/FeaturedVaultCard/FeaturedVaultApyLabel.tsx
@@ -1,39 +1,25 @@
 import { styled } from '@repo/styles/jsx';
-import { memo, useCallback, useMemo, type MouseEvent } from 'react';
+import { memo, useCallback, type MouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AVG_APY_PERIODS } from '../../../../helpers/apy.ts';
-import type { AvgApySortType } from '../../../data/reducers/filtered-vaults-types.ts';
-import { filteredVaultsActions } from '../../../data/reducers/filtered-vaults.ts';
-import { selectFilterAvgApySort } from '../../../data/selectors/filtered-vaults.ts';
-import { useAppDispatch, useAppSelector } from '../../../data/store/hooks.ts';
-
-const APY_PERIODS: AvgApySortType[] = ['default', ...AVG_APY_PERIODS];
+import { useSubSort } from '../../../../hooks/useSubSort.ts';
 
 export const FeaturedVaultApyLabel = memo(function FeaturedVaultApyLabel() {
   const { t } = useTranslation();
-  const dispatch = useAppDispatch();
-  const subSort = useAppSelector(selectFilterAvgApySort);
-
-  const prefix = useMemo(() => {
-    if (subSort === 'default') return t('Filter-SortApy-default-Featured');
-    return t('Filter-SortApy-avgNd-Featured', { count: subSort });
-  }, [t, subSort]);
+  const { next, label } = useSubSort('apy');
 
   const handleClick = useCallback(
     (e: MouseEvent<HTMLButtonElement>) => {
       e.preventDefault();
       e.stopPropagation();
-      const idx = APY_PERIODS.indexOf(subSort);
-      const next = APY_PERIODS[(idx + 1) % APY_PERIODS.length];
-      dispatch(filteredVaultsActions.update({ subSort: { apy: next } }));
+      next();
     },
-    [dispatch, subSort]
+    [next]
   );
 
   return (
     <Label>
       <Prefix type="button" onClick={handleClick}>
-        {prefix}
+        {label}
       </Prefix>
       <span>{t('VaultStat-APY')}</span>
     </Label>
@@ -61,6 +47,7 @@ const Prefix = styled('button', {
     textDecoration: 'underline',
     textDecorationColor: 'text.underline',
     textUnderlineOffset: '3px',
+    textTransform: 'uppercase',
     _hover: {
       color: 'text.light',
     },

--- a/src/features/home/components/Filters/components/Sort/Sort.tsx
+++ b/src/features/home/components/Filters/components/Sort/Sort.tsx
@@ -120,9 +120,9 @@ const SortContent = memo<SortContentProps>(function SortContent({ onClose, open 
       dispatch(
         filteredVaultsActions.update({
           sort: pendingState.sort,
-          subSort: {
-            apy: pendingState.sort === 'apy' ? pendingState.subSort || 'default' : 'default',
-          },
+          ...(pendingState.sort === 'apy' ?
+            { subSort: { apy: pendingState.subSort || 'default' } }
+          : {}),
         })
       );
     }

--- a/src/features/home/components/Vaults/components/VaultsSort/SubColumnSort.tsx
+++ b/src/features/home/components/Vaults/components/VaultsSort/SubColumnSort.tsx
@@ -1,50 +1,19 @@
 import { styled } from '@repo/styles/jsx';
-import { memo, useCallback, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useAppDispatch, useAppSelector } from '../../../../../data/store/hooks.ts';
-import {
-  type SortWithSubSort,
-  type SubSortsState,
-} from '../../../../../data/reducers/filtered-vaults-types.ts';
-import { filteredVaultsActions } from '../../../../../data/reducers/filtered-vaults.ts';
-import { selectFilterSubSort } from '../../../../../data/selectors/filtered-vaults.ts';
-
-export type FilterSubColumn<T extends SortWithSubSort> = {
-  label: string;
-  value: SubSortsState[T];
-};
+import { memo } from 'react';
+import { type SortWithSubSort } from '../../../../../data/reducers/filtered-vaults-types.ts';
+import { useSubSort } from '../../../../../../hooks/useSubSort.ts';
 
 export type SubColumnSortProps<T extends SortWithSubSort> = {
-  columnSelected: boolean;
   columnKey: T;
-  subColumns: FilterSubColumn<T>[];
 };
 
 export const SubColumnSort = memo(function SubColumnSort<T extends SortWithSubSort>({
-  columnSelected,
   columnKey,
-  subColumns,
 }: SubColumnSortProps<T>) {
-  const { t } = useTranslation();
-  const subKey = useAppSelector(state => selectFilterSubSort(state, columnKey));
-  const dispatch = useAppDispatch();
-  const index = useMemo(
-    () => subColumns.findIndex(key => key.value === subKey),
-    [subKey, subColumns]
-  );
-  if (index === -1) {
-    throw new Error(`Invalid subKey: ${subKey} of column: ${columnKey}`);
-  }
-
-  const handleClick = useCallback(() => {
-    const nextIndex = (index + 1) % subColumns.length;
-    const value = subColumns[nextIndex].value;
-    dispatch(filteredVaultsActions.update({ subSort: { [columnKey]: value } }));
-  }, [columnKey, index, subColumns, dispatch]);
-
+  const { next, label, parentSelected } = useSubSort(columnKey);
   return (
-    <SortButton data-active={columnSelected || undefined} onClick={handleClick}>
-      {t(subColumns[index].label)}
+    <SortButton data-active={parentSelected || undefined} onClick={next}>
+      {label}
     </SortButton>
   );
 });

--- a/src/features/home/components/Vaults/components/VaultsSort/TableHeaderSort.tsx
+++ b/src/features/home/components/Vaults/components/VaultsSort/TableHeaderSort.tsx
@@ -1,42 +1,25 @@
 import { styled } from '@repo/styles/jsx';
 import { memo, useCallback } from 'react';
 import { SortColumnHeader } from '../../../../../../components/SortColumnHeader/SortColumnHeader.tsx';
-import { AVG_APY_PERIODS } from '../../../../../../helpers/apy.ts';
 import { useAppDispatch, useAppSelector } from '../../../../../data/store/hooks.ts';
-import type {
-  FilterValues,
-  SortType,
-  SortWithSubSort,
-} from '../../../../../data/reducers/filtered-vaults-types.ts';
+import type { FilterValues, SortType } from '../../../../../data/reducers/filtered-vaults-types.ts';
 import { filteredVaultsActions } from '../../../../../data/reducers/filtered-vaults.ts';
 import {
   selectFilterEffectiveSort,
   selectFilterSortDirection,
 } from '../../../../../data/selectors/filtered-vaults.ts';
-import { type FilterSubColumn, SubColumnSort } from './SubColumnSort.tsx';
-
-type SubKeyField<T extends SortType> =
-  T extends SortWithSubSort ? { subKeys: FilterSubColumn<T>[] } : unknown;
+import { SubColumnSort } from './SubColumnSort.tsx';
+import { hasSubSort } from '../../../../../../hooks/useSubSort.ts';
 
 type SortColumn = {
   [K in SortType]: {
     label: string;
     value: K;
-  } & SubKeyField<K>;
+  };
 }[SortType];
 
 const SORT_COLUMNS = [
-  {
-    label: 'Filter-SortApy',
-    value: 'apy',
-    subKeys: [
-      { label: 'Filter-SortApy-default', value: 'default' },
-      ...AVG_APY_PERIODS.map(period => ({
-        label: `Filter-SortApy-avg${period}d`,
-        value: period,
-      })),
-    ],
-  },
+  { label: 'Filter-SortApy', value: 'apy' },
   { label: 'Filter-SortDaily', value: 'daily' },
   { label: 'Filter-SortTvl', value: 'tvl' },
   { label: 'Filter-SortDeposited', value: 'depositValue' },
@@ -63,22 +46,14 @@ export const TableHeaderSort = memo(function TableHeaderSort() {
 
   return (
     <HeaderRow>
-      {SORT_COLUMNS.map(({ label, value, subKeys }) => (
+      {SORT_COLUMNS.map(({ label, value }) => (
         <SortColumnHeader
           key={value}
           label={label}
           sortKey={value}
           sorted={sortField === value ? sortDirection : 'none'}
           onChange={handleSort}
-          before={
-            subKeys && (
-              <SubColumnSort
-                columnSelected={sortField === value}
-                columnKey={value}
-                subColumns={subKeys}
-              />
-            )
-          }
+          before={hasSubSort(value) && <SubColumnSort columnKey={value} />}
         />
       ))}
     </HeaderRow>

--- a/src/hooks/useSubSort.ts
+++ b/src/hooks/useSubSort.ts
@@ -1,0 +1,61 @@
+import { useCallback, useMemo } from 'react';
+import type {
+  SortType,
+  SortWithSubSort,
+  SubSortsState,
+} from '../features/data/reducers/filtered-vaults-types.ts';
+import { useAppDispatch, useAppSelector } from '../features/data/store/hooks.ts';
+import {
+  selectFilterEffectiveSort,
+  selectFilterSubSort,
+} from '../features/data/selectors/filtered-vaults.ts';
+import { AVG_APY_PERIODS } from '../helpers/apy.ts';
+import { filteredVaultsActions } from '../features/data/reducers/filtered-vaults.ts';
+import { useTranslation } from 'react-i18next';
+
+type SubColumnValuesMap = {
+  [K in SortWithSubSort]: { label: string; value: SubSortsState[K] }[];
+};
+
+const SUB_COLUMNS = {
+  apy: [
+    { label: 'Filter-SortApy-default', value: 'default' },
+    ...AVG_APY_PERIODS.map(period => ({
+      label: `Filter-SortApy-avg${period}d`,
+      value: period,
+    })),
+  ],
+} as const satisfies SubColumnValuesMap;
+
+export function hasSubSort(columnKey: SortType): columnKey is SortWithSubSort {
+  return SUB_COLUMNS[columnKey as SortWithSubSort] !== undefined;
+}
+
+export function useSubSort(columnKey: SortWithSubSort) {
+  const { t } = useTranslation();
+  const sortField = useAppSelector(selectFilterEffectiveSort);
+  const parentSelected = sortField === columnKey;
+  const value = useAppSelector(state => selectFilterSubSort(state, columnKey));
+  const entries = SUB_COLUMNS[columnKey];
+  const dispatch = useAppDispatch();
+  const index = useMemo(() => entries.findIndex(key => key.value === value), [value, entries]);
+  if (index === -1) {
+    throw new Error(`Invalid sub value ${value} of column: ${columnKey}`);
+  }
+  const entry = entries[index];
+  const nextIndex = (index + 1) % entries.length;
+  const nextEntry = entries[nextIndex];
+
+  const next = useCallback(() => {
+    dispatch(
+      filteredVaultsActions.update({
+        subSort: { [columnKey]: nextEntry.value },
+      })
+    );
+  }, [columnKey, nextEntry, dispatch]);
+
+  return useMemo(
+    () => ({ value: entry.value, label: t(entry.label), next, parentSelected }),
+    [t, entry, next, parentSelected]
+  );
+}

--- a/src/locales/en/main.json
+++ b/src/locales/en/main.json
@@ -168,8 +168,6 @@
   "NoResults-ViewConnectedDashboard": "View Your Dashboard",
   "FeaturedVaults-Title": "Spotlight",
   "FeaturedVaults-Title-Description": "New launches, hidden gems, and vaults worth a closer look",
-  "Filter-SortApy-default-Featured": "CURRENT",
-  "Filter-SortApy-avgNd-Featured": "{{count}}-DAY",
   "VaultStat-AvgAPY": "{{count}}-Day APY",
   "VaultStat-APY": "APY",
   "VaultStat-APR": "APR",


### PR DESCRIPTION
- changing apy sub field does not change main sort
- changing apy sub field does not count towards user picked sort, so relevance sort is kept
- dedupe sub field selection via new hook (+ label strings)