### PR TITLE
Fix RH Up vLP Deposit Issue

### DIFF
--- a/src/config/vault/robinhood.json
+++ b/src/config/vault/robinhood.json
@@ -256,7 +256,7 @@
     "risks": {
       "complex": true,
       "curated": false,
-      "notAudited": true,
+      "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
       "notTimelocked": true,
@@ -298,7 +298,7 @@
     "risks": {
       "complex": true,
       "curated": false,
-      "notAudited": true,
+      "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
       "notTimelocked": true,
@@ -453,7 +453,7 @@
       "updatedAt": 1784532533,
       "complex": false,
       "curated": false,
-      "notAudited": true,
+      "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
       "notTimelocked": true,
@@ -610,7 +610,7 @@
     "risks": {
       "complex": true,
       "curated": false,
-      "notAudited": true,
+      "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
       "notTimelocked": true,
@@ -651,7 +651,7 @@
     "risks": {
       "complex": true,
       "curated": false,
-      "notAudited": true,
+      "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
       "notTimelocked": true,
@@ -696,7 +696,7 @@
     "risks": {
       "complex": true,
       "curated": false,
-      "notAudited": true,
+      "notAudited": false,
       "notBattleTested": false,
       "notCorrelated": true,
       "notTimelocked": true,

--- a/src/config/zap/amm/robinhood.json
+++ b/src/config/zap/amm/robinhood.json
@@ -4,7 +4,7 @@
     "name": "Up33",
     "type": "solidly",
     "routerAddress": "0xf5198743240fAC98db71868F34c70139b1eb0474",
-    "factoryAddress": "not-used",
+    "factoryAddress": "0xFA5429AEBa338BEa2BFcc1b9a889862Ee395bc28",
     "pairInitHash": "not-used",
     "minimumLiquidity": "1000",
     "swapFeeNumerator": "2",

--- a/src/config/zap/amm/robinhood.json
+++ b/src/config/zap/amm/robinhood.json
@@ -4,7 +4,7 @@
     "name": "Up33",
     "type": "solidly",
     "routerAddress": "0xf5198743240fAC98db71868F34c70139b1eb0474",
-    "factoryAddress": "0xFA5429AEBa338BEa2BFcc1b9a889862Ee395bc28",
+    "factoryAddress": "not-used",
     "pairInitHash": "not-used",
     "minimumLiquidity": "1000",
     "swapFeeNumerator": "2",

--- a/src/features/data/apis/amm/amm.ts
+++ b/src/features/data/apis/amm/amm.ts
@@ -62,7 +62,7 @@ const mapSolidly: Record<string, typeof SolidlyPool> = {
   'scroll-tokan': TokanSolidlyPool,
   'sonic-shadow': SpiritSwapV2SolidlyPool,
   'avax-blackhole': BlackholeSolidlyPool,
-  'robinhood-up33': VelodromeSolidlyPool,
+  'robinhood-up33': VelodromeV2SolidlyPool,
 };
 
 export async function getUniswapLikePool(


### PR DESCRIPTION
**Issue:** Zaps into Up vLPs are blocked by invalid factory address `not-used`.

**Solution:** Add factory address and update amm.ts to map Up as a Velodrome V2 Solidly Pool. 

**Example Error:** 
<img width="358" height="358" alt="Screenshot 2026-08-11 at 16 44 55" src="https://github.com/user-attachments/assets/9ce0a1fa-8b44-4076-b055-6e1a80ce783e" />

Have also added changes to UP token products to remove the no audit risk, as the protocol and token now have a public audit released.