### PR TITLE
Fix confirm-time requote staleness: execute the quote that is displayed

### DIFF
--- a/src/features/data/actions/wallet/cowcentrated.ts
+++ b/src/features/data/actions/wallet/cowcentrated.ts
@@ -11,7 +11,8 @@ import { selectWalletAddress } from '../../selectors/wallet.ts';
 import { getWalletConnectionApi } from '../../apis/instances.ts';
 import { rpcClientManager } from '../../apis/rpc-contract/rpc-manager.ts';
 import { selectChainById } from '../../selectors/chains.ts';
-import { selectTransactSelectedQuote, selectTransactSlippage } from '../../selectors/transact.ts';
+import { selectTransactSlippage } from '../../selectors/transact.ts';
+import type { TokenAmount } from '../../apis/transact/transact-types.ts';
 import { fetchWalletContract } from '../../apis/rpc-contract/viem-contract.ts';
 import { BeefyCowcentratedLiquidityVaultAbi } from '../../../../config/abi/BeefyCowcentratedLiquidityVaultAbi.ts';
 import { getGasPriceOptions } from '../../utils/gas-utils.ts';
@@ -23,7 +24,8 @@ import { selectTokenByAddress } from '../../selectors/tokens.ts';
 export const v3Deposit = (
   vault: VaultCowcentrated,
   amountToken0: BigNumber,
-  amountToken1: BigNumber
+  amountToken1: BigNumber,
+  expectedShares: BigNumber
 ) => {
   return captureWalletErrors(async (dispatch, getState) => {
     txStart(dispatch);
@@ -52,10 +54,7 @@ export const v3Deposit = (
     );
     const gasPrices = await getGasPriceOptions(chain);
 
-    const estimatedLiquidity = toWeiString(
-      selectTransactSelectedQuote(state)?.outputs[0].amount.times(0.99),
-      18
-    );
+    const estimatedLiquidity = toWeiString(expectedShares.times(0.99), 18);
     txWallet(dispatch);
 
     const transaction = contract.write.deposit(
@@ -73,7 +72,7 @@ export const v3Deposit = (
       publicClient,
       {
         spender: vault.contractAddress,
-        amount: selectTransactSelectedQuote(state)?.outputs[0].amount,
+        amount: expectedShares,
         token: depositToken,
       },
       {
@@ -86,7 +85,12 @@ export const v3Deposit = (
     );
   });
 };
-export const v3Withdraw = (vault: VaultCowcentrated, withdrawAmount: BigNumber, max: boolean) => {
+export const v3Withdraw = (
+  vault: VaultCowcentrated,
+  withdrawAmount: BigNumber,
+  max: boolean,
+  expectedOutputs: TokenAmount[]
+) => {
   return captureWalletErrors(async (dispatch, getState) => {
     txStart(dispatch);
     const state = getState();
@@ -108,8 +112,7 @@ export const v3Withdraw = (vault: VaultCowcentrated, withdrawAmount: BigNumber, 
     );
     const gasPrices = await getGasPriceOptions(chain);
 
-    const outputs = selectTransactSelectedQuote(state).outputs;
-    const minOutputs = slipAllBy(outputs, slippage);
+    const minOutputs = slipAllBy(expectedOutputs, slippage);
     const minOutputsWei = minOutputs.map(output =>
       toWeiString(output.amount, output.token.decimals)
     );

--- a/src/features/data/actions/wallet/transact.ts
+++ b/src/features/data/actions/wallet/transact.ts
@@ -46,11 +46,6 @@ export async function getTransactSteps(
 ): Promise<Step[]> {
   const steps: Step[] = [];
   const state = getState();
-  const isCrossChain = isCrossChainOption(quote.option);
-  console.log('[transact] getTransactSteps: start', {
-    strategyId: quote.option.strategyId,
-    isCrossChain,
-  });
 
   // Prefetch gas price for cross-chain options (runs in background, consumed by crossChainZapExecuteOrder)
   if (isCrossChainOption(quote.option)) {
@@ -103,16 +98,9 @@ export async function getTransactSteps(
   requotePromise.catch(() => {});
 
   // Build the step (~5-8s, re-quote runs in parallel)
-  let originalStep: Step;
-  if (isDepositQuote(quote)) {
-    originalStep = await api.fetchDepositStep(quote, getState, t);
-  } else if (isWithdrawQuote(quote)) {
-    originalStep = await api.fetchWithdrawStep(quote, getState, t);
-  } else {
-    throw new Error(`Invalid quote`);
-  }
+  const originalStep = await fetchStepForQuote(quote, getState, t);
 
-  steps.push(wrapStepConfirmQuote(originalStep, quote, prefetchedRequote));
+  steps.push(wrapStepConfirmQuote(originalStep, quote, prefetchedRequote, t));
 
   return steps;
 }
@@ -169,7 +157,8 @@ export function transactStepsClaimGov(vault: VaultGov, t: TFunction<Namespace>):
 function wrapStepConfirmQuote(
   originalStep: Step,
   originalQuote: TransactQuote,
-  prefetchedRequote: PrefetchedRequote
+  prefetchedRequote: PrefetchedRequote,
+  t: TFunction<Namespace>
 ): Step {
   const action: BeefyThunk = async function (dispatch, getState) {
     const requestId = nanoid();
@@ -196,7 +185,6 @@ function wrapStepConfirmQuote(
       const maxSlippage = selectTransactSlippage(state);
       const newQuote = quotes.find(quote => quote.option.id === originalQuote.option.id);
       const minAllowedRatio = new BigNumber(1 - maxSlippage * 0.1); // max 10% of slippage lower
-      console.log('minAllowedRatio', minAllowedRatio.toString(10));
 
       if (!newQuote) {
         throw new Error(`Failed to get new quote.`);
@@ -221,8 +209,9 @@ function wrapStepConfirmQuote(
         }
       }
 
-      // Perform original action if no changes
+      // No significant changes: rebuild the step from the new quote so execution matches what is displayed
       if (significantChanges.length === 0) {
+        const newStep = await fetchStepForQuote(newQuote, getState, t);
         dispatch(
           transactConfirmUnneeded({
             requestId,
@@ -230,8 +219,7 @@ function wrapStepConfirmQuote(
             originalQuoteId: originalQuote.id,
           })
         );
-        const result = await originalStep.action(dispatch, getState, undefined);
-        return result;
+        return await newStep.action(dispatch, getState, undefined);
       }
 
       console.debug('original', originalQuote);
@@ -265,6 +253,21 @@ function wrapStepConfirmQuote(
     ...originalStep,
     action,
   };
+}
+
+async function fetchStepForQuote(
+  quote: TransactQuote,
+  getState: BeefyStateFn,
+  t: TFunction<Namespace>
+): Promise<Step> {
+  const api = await getTransactApi();
+  if (isDepositQuote(quote)) {
+    return api.fetchDepositStep(quote, getState, t);
+  } else if (isWithdrawQuote(quote)) {
+    return api.fetchWithdrawStep(quote, getState, t);
+  } else {
+    throw new Error(`Invalid quote`);
+  }
 }
 
 async function fetchFreshRequote(

--- a/src/features/data/apis/transact/vaults/CowcentratedVaultType.ts
+++ b/src/features/data/apis/transact/vaults/CowcentratedVaultType.ts
@@ -192,7 +192,12 @@ export class CowcentratedVaultType implements ICowcentratedVaultType {
     return {
       step: 'deposit',
       message: t('Vault-TxnConfirm', { type: t('Deposit-noun') }),
-      action: v3Deposit(this.vault, quote.inputs[0].amount, quote.inputs[1].amount),
+      action: v3Deposit(
+        this.vault,
+        quote.inputs[0].amount,
+        quote.inputs[1].amount,
+        quote.outputs[0].amount
+      ),
       pending: false,
       extraInfo: { zap: false, vaultId: quote.option.vaultId },
     };
@@ -274,7 +279,7 @@ export class CowcentratedVaultType implements ICowcentratedVaultType {
     return {
       step: 'withdraw',
       message: t('Vault-TxnConfirm', { type: t('Withdraw-noun') }),
-      action: v3Withdraw(this.vault, input.amount, input.max ?? false),
+      action: v3Withdraw(this.vault, input.amount, input.max ?? false, quote.outputs),
       pending: false,
       extraInfo: { zap: false, vaultId: quote.option.vaultId },
     };


### PR DESCRIPTION
## Problem
The confirm-time re-quote validated a fresh quote (Q1) against the original (Q0), stored Q1 in redux (so the UI displays it) — but then executed the step built from Q0. A time-of-check/time-of-use bug: what the user sees and what executes could differ (bounded by the tolerance gate).

Worse, `v3Deposit`/`v3Withdraw` were the only wallet actions reading the quote from redux at execution time, so a single CLM `deposit()` call could mix Q0 closure amounts with Q1 min-liquidity.

## Fix
- `wrapStepConfirmQuote`: when the requote passes the tolerance gate, rebuild the step from the new quote (via a shared `fetchStepForQuote` helper) and execute that, instead of the stale pre-built action. Build happens before the `transactConfirmUnneeded` dispatch so a build failure leaves state untouched.
- `v3Deposit`/`v3Withdraw` now take quote outputs as arguments; all `selectTransactSelectedQuote` reads removed — one contract call can no longer mix two quotes.
- Removed two debug `console.log`s in this path.

## Notes
- Known cost: CrossChain and V2V strategies build their zap assembly eagerly, so they pay it twice (stepper start + confirm).
- Manual QA pending (CLM direct deposit/withdraw, plain zap, CCTP, drift → ConfirmNotice path).