### PR TITLE
fix search placeholder clipping on mobile

### DIFF
--- a/src/features/dashboard/components/AddressInput/AddressInput.tsx
+++ b/src/features/dashboard/components/AddressInput/AddressInput.tsx
@@ -260,7 +260,8 @@ const SearchIndicatorLayout = styled('div', {
 const transparentRoot = css.raw({
   // mobile: collapsed input shows the "Search" placeholder + icon
   width: '79px',
-  minWidth: 0,
+  // the width above does not fit the placeholder; never shrink below it
+  minWidth: 'fit-content',
   transition: 'width 0.2s ease-in-out',
   gap: 0,
   '& .BaseInput-input': {
@@ -276,6 +277,8 @@ const transparentRoot = css.raw({
 const transparentRootActive = css.raw({
   // mobile (active): take the full row available
   width: '100%',
+  // typed value must still shrink and scroll rather than widen the row
+  minWidth: 0,
   sm: {
     // tablet+: handled by field-sizing on the input itself
     width: 'auto',


### PR DESCRIPTION
The collapsed mobile search box is a hardcoded `79px`, leaving the input `51px` — `0.09px` less than the `SEARCH` placeholder needs at 12px/500 with 0.8px letter-spacing, so it renders as `SEARC…` on every mobile width. What varies between devices is font rasterisation, not layout, which is why it looks fine to some people.

Adds a `min-width: fit-content` floor while collapsed, plus an explicit `min-width: 0` on the active state so a typed value can still shrink and scroll its text internally. The inner input already has `field-sizing: content`; the `79px` cap is what was clamping it. `width: 79px` stays as the expand-transition start value.

Also fixes a worse case: at 320px with a 16-character ENS label, the flex row squeezes the input to `41px` (`SEAR…`). The floor holds it and the address — already ellipsising at that width — absorbs one character.

Measured across 320/360/375/390/414/430/599px × {short hex, 16-char ENS} × {collapsed, full 0x address typed, 60-char string}: placeholder never clipped, no row or document overflow, `DASHBOARD /` never cut, typed behaviour identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
